### PR TITLE
Generate random license key in specific format (a-f0-9-)

### DIFF
--- a/src/api/management/commands/populate_db_licensekey.py
+++ b/src/api/management/commands/populate_db_licensekey.py
@@ -6,13 +6,20 @@ import string
 class Command(BaseCommand):
     help = 'Generate a random license key and add it to the database'
 
+    def generate_random_string(self, length):
+        characters = 'abcdef0123456789'
+        random_string = ''.join(random.choices(characters, k=length))
+        return random_string
+
     def handle(self, *args, **kwargs):
         if LicenseKey.objects.exists():
             self.stdout.write(self.style.SUCCESS('License key already exists in the database'))
             return
         
-        # Generate a random license key
-        license_key = ''.join(random.choices(string.ascii_uppercase + string.digits, k=32))
+        # Generate a random license key in the format XXXXXXXX-XXXXXXXX-XXXXXXXX
+        # with the following criteria: [a-f0-9-]
+        license_key = self.generate_random_string(8) + '-' + self.generate_random_string(8) + '-' + self.generate_random_string(8)
+        
 
         # Add the license key to the database
         LicenseKey.objects.create(licensekey=license_key)


### PR DESCRIPTION
The `populate_db_licensekey.py` script has been updated to generate a random license key in the format XXXXXXXX-XXXXXXXX-XXXXXXXX, where X can be any lowercase letter from a to f or any digit from 0 to 9. This change ensures that the license key follows a specific pattern and improves consistency in the database.