### PR TITLE
Fix: Disabled rules should not affect ruleset compliance status

### DIFF
--- a/src/api/utils/compliance.py
+++ b/src/api/utils/compliance.py
@@ -31,7 +31,8 @@ def check_device_compliance(device, report):
                 'alert': rule.alert,
                 'compliant': rule_compliant
             })
-            if not rule_compliant:
+            # Only enabled rules affect ruleset compliance status
+            if rule.enabled and not rule_compliant:
                 ruleset_compliant = False
         
         ruleset_dict['compliant'] = ruleset_compliant


### PR DESCRIPTION
Fixes #66

## Summary

This PR fixes a bug where disabled rules were still affecting the compliance status of rulesets. Now, only enabled rules determine whether a ruleset is compliant.

## Changes

- Updated `check_device_compliance()` in `src/api/utils/compliance.py` to check `rule.enabled` before marking a ruleset as non-compliant
- Disabled rules are still evaluated and displayed in the UI for visibility, but their compliance status no longer affects the overall ruleset status

## Behavior

**Before:** A ruleset would be marked as non-compliant if any rule (including disabled ones) failed.

**After:** A ruleset is only marked as non-compliant if an enabled rule fails. Disabled rules are evaluated for display purposes but don't affect compliance status.

## Testing

- All existing tests pass (157 passed, 4 pre-existing failures unrelated to this change)
- The fix aligns with the behavior of `PolicyRuleset.evaluate()` method which already correctly checks `rule.enabled`