### PR TITLE
Add enrollment toggle for daily Lynis systemd runs

### DIFF
--- a/docs/installation/client-setup.md
+++ b/docs/installation/client-setup.md
@@ -32,6 +32,7 @@ The enrollment script performs the following actions:
 - **Dependencies**: Installs required packages (Lynis, etc.).
 - **Configuration**: Configures the Lynis custom profile (`custom.prf`) with the correct server URL and license key.
 - **First Audit**: Performs the first audit with upload enabled (results will appear in TrikuSec).
+- **Daily timer (optional)**: When **Enable daily reports (systemd)** is toggled on (enabled by default), the script installs the upstream `lynis.service`/`lynis.timer` units and enables the timer so reports continue every day.
 
 ### Configuration
 
@@ -102,12 +103,16 @@ lynis audit system --upload --quick --profile /etc/lynis/custom.prf
 
 Keep Lynis results current by scheduling a daily execution through `systemd` timers:
 
+> **Tip:** If you leave the **Enable daily reports (systemd)** toggle enabled in *Settings → Enrollment configuration*, the automatic enroll script performs steps 1–3 below for you. Use the manual steps only when configuring hosts by hand or after disabling that toggle.
+
 1. **Create service and timer files**:
    - `/etc/systemd/system/lynis.service`
    - `/etc/systemd/system/lynis.timer`
 
    You can copy the reference units shipped by the Lynis project and adapt them to your paths and options as needed.  
    Source: [Lynis systemd units](https://github.com/CISOfy/lynis/tree/master/extras/systemd)
+   
+   TrikuSec also ships copies under `docs/reference/systemd/` for convenience.
 
 2. **Reload systemd to pick up the new units**:
 

--- a/docs/reference/systemd/lynis.service
+++ b/docs/reference/systemd/lynis.service
@@ -1,0 +1,31 @@
+#################################################################################
+#
+# Lynis service file for systemd
+#
+#################################################################################
+#
+# - Adjust path to link to location where Lynis binary is installed
+#
+# - Place this file together with the lynis.timer file in the related
+#   systemd directory (e.g. /etc/systemd/system/)
+#
+# - See details in lynis.timer file
+#
+#################################################################################
+
+[Unit]
+Description=Security audit and vulnerability scanner
+Documentation=https://cisofy.com/docs/
+
+[Service]
+Nice=19
+IOSchedulingClass=best-effort
+IOSchedulingPriority=7
+Type=simple
+ExecStart=/usr/sbin/lynis audit system --cronjob
+
+[Install]
+WantedBy=multi-user.target
+
+#EOF
+

--- a/docs/reference/systemd/lynis.timer
+++ b/docs/reference/systemd/lynis.timer
@@ -1,0 +1,30 @@
+#################################################################################
+#
+# Lynis timer file for systemd
+#
+#################################################################################
+#
+# - Place this file together with the lynis.service file in the related
+#   systemd directory (e.g. /etc/systemd/system)
+#
+# - Tell systemd you made changes
+#   systemctl daemon-reload
+#
+# - Enable and start the timer (so no reboot is needed):
+#   systemctl enable --now lynis.timer
+#
+#################################################################################
+
+[Unit]
+Description=Daily timer for the Lynis security audit and vulnerability scanner
+
+[Timer]
+OnCalendar=daily
+RandomizedDelaySec=1800
+Persistent=false
+
+[Install]
+WantedBy=timers.target
+
+#EOF
+

--- a/src/api/migrations/0027_enrollmentsettings_enable_daily_reports.py
+++ b/src/api/migrations/0027_enrollmentsettings_enable_daily_reports.py
@@ -1,0 +1,17 @@
+from django.db import migrations, models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('api', '0026_device_ip_address_device_mac_address_and_more'),
+    ]
+
+    operations = [
+        migrations.AddField(
+            model_name='enrollmentsettings',
+            name='enable_daily_reports',
+            field=models.BooleanField(default=True),
+        ),
+    ]
+

--- a/src/api/models.py
+++ b/src/api/models.py
@@ -175,6 +175,7 @@ class EnrollmentSettings(models.Model):
     ignore_ssl_errors = models.BooleanField(default=False)
     overwrite_lynis_profile = models.BooleanField(default=False)
     use_cisofy_repo = models.BooleanField(default=False)
+    enable_daily_reports = models.BooleanField(default=True)
     additional_packages = models.CharField(max_length=255, default='rkhunter auditd')
     skip_tests = models.CharField(max_length=255, blank=True, default='')
     updated_at = models.DateTimeField(auto_now=True)

--- a/src/api/tests.py
+++ b/src/api/tests.py
@@ -374,6 +374,35 @@ class TestEnrollScript:
         # Verify the print_info statement for skip tests (actual behavior, not comment)
         assert 'print_info "Configuring Lynis to skip tests: ${SKIP_TESTS}"' in body
 
+    def test_enroll_script_daily_reports_enabled(self, test_license_key):
+        settings = EnrollmentSettings.get_settings()
+        settings.enable_daily_reports = True
+        settings.save()
+
+        client = Client()
+        response = client.get(reverse('enroll_sh'), {'licensekey': test_license_key.licensekey})
+
+        assert response.status_code == 200
+        body = response.content.decode()
+
+        assert 'ENABLE_DAILY_REPORTS=true' in body
+        assert 'Configuring Daily Lynis systemd timer' in body
+        assert 'systemctl enable --now lynis.timer' in body
+
+    def test_enroll_script_daily_reports_disabled(self, test_license_key):
+        settings = EnrollmentSettings.get_settings()
+        settings.enable_daily_reports = False
+        settings.save()
+
+        client = Client()
+        response = client.get(reverse('enroll_sh'), {'licensekey': test_license_key.licensekey})
+
+        assert response.status_code == 200
+        body = response.content.decode()
+
+        assert 'ENABLE_DAILY_REPORTS=false' in body
+        assert 'Daily Lynis systemd timer disabled in TrikuSec settings.' in body
+
     def test_check_license_invalid_method_put(self):
         """Test PUT method returns 405."""
         client = Client()

--- a/src/api/views.py
+++ b/src/api/views.py
@@ -294,6 +294,7 @@ def enroll_sh(request):
         'ignore_ssl_errors': enrollment_settings.ignore_ssl_errors,
         'overwrite_lynis_profile': enrollment_settings.overwrite_lynis_profile,
         'use_cisofy_repo': enrollment_settings.use_cisofy_repo,
+        'enable_daily_reports': enrollment_settings.enable_daily_reports,
         'additional_packages': additional_packages,
         'skip_tests': skip_tests,
         'plugin_urls': plugin_urls,

--- a/src/frontend/forms.py
+++ b/src/frontend/forms.py
@@ -219,7 +219,12 @@ class ActivityIgnorePatternForm(forms.ModelForm):
 class EnrollmentSettingsForm(forms.ModelForm):
     class Meta:
         model = EnrollmentSettings
-        fields = ['ignore_ssl_errors', 'overwrite_lynis_profile', 'use_cisofy_repo']
+        fields = [
+            'ignore_ssl_errors',
+            'overwrite_lynis_profile',
+            'use_cisofy_repo',
+            'enable_daily_reports',
+        ]
         widgets = {
             'ignore_ssl_errors': forms.CheckboxInput(attrs={
                 'class': 'mt-1 block border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-gray-800',
@@ -230,6 +235,9 @@ class EnrollmentSettingsForm(forms.ModelForm):
             'use_cisofy_repo': forms.CheckboxInput(attrs={
                 'class': 'mt-1 block border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-gray-800',
             }),
+            'enable_daily_reports': forms.CheckboxInput(attrs={
+                'class': 'mt-1 block border-gray-300 rounded-md shadow-sm focus:ring-indigo-500 focus:border-indigo-500 text-gray-800',
+            }),
         }
 
     def __init__(self, *args, **kwargs):
@@ -237,6 +245,7 @@ class EnrollmentSettingsForm(forms.ModelForm):
         self.fields['ignore_ssl_errors'].help_text = 'Skip downloading and trusting the server certificate. Enable this only if the servers certificate is self-signed and you don\'t want to install the certificate into the system truststore.'
         self.fields['overwrite_lynis_profile'].help_text = 'Allow the installer to replace /etc/lynis/custom.prf even if it already exists.'
         self.fields['use_cisofy_repo'].help_text = 'Install Lynis from the official CISOfy repository instead of the system repository. This ensures you get the latest version of Lynis.'
+        self.fields['enable_daily_reports'].help_text = 'Install and enable the upstream Lynis systemd service/timer so clients upload a report every day.'
 
 class EnrollmentPluginForm(forms.ModelForm):
     class Meta:

--- a/src/frontend/templates/settings.html
+++ b/src/frontend/templates/settings.html
@@ -95,6 +95,23 @@
                     </div>
                 </div>
 
+                <div class="flex items-start">
+                    <div class="flex items-center h-5">
+                        {{ settings_form.enable_daily_reports }}
+                    </div>
+                    <div class="ml-3 text-sm">
+                        <label for="{{ settings_form.enable_daily_reports.id_for_label }}" class="font-medium text-gray-900">
+                            Enable daily Lynis systemd timer
+                        </label>
+                        <p class="text-gray-500">
+                            {{ settings_form.enable_daily_reports.help_text }}
+                        </p>
+                        {% if settings_form.enable_daily_reports.errors %}
+                            <p class="mt-2 text-sm text-red-600">{{ settings_form.enable_daily_reports.errors|first }}</p>
+                        {% endif %}
+                    </div>
+                </div>
+
                 <div>
                     <button type="button" class="w-full flex items-center justify-between text-left bg-gray-50 border border-gray-200 rounded-md p-4 hover:bg-gray-100 transition-colors" data-packages-toggle>
                         <div class="flex items-center space-x-2">


### PR DESCRIPTION
## Summary
- add enable_daily_reports flag to enrollment settings + UI
- extend enroll script to install/enable Lynis systemd service/timer when option is on and ship reference units
- document the new behavior and cover it with template tests

## Testing
- docker compose -f docker-compose.dev.yml --profile test run --rm test pytest api/tests.py::TestEnrollScript -k daily


Fixes #72 