### PR TITLE
Scope self-signed cert to Lynis client only

### DIFF
--- a/docs/installation/client-setup.md
+++ b/docs/installation/client-setup.md
@@ -28,7 +28,7 @@ This is the recommended method as it handles dependencies and configuration auto
 
 The enrollment script performs the following actions:
 
-- **SSL Configuration**: Adds the Lynis API SSL certificate to the trust store (only when using self-signed certificates).
+- **SSL Configuration**: Downloads the Lynis API SSL certificate and saves it to `/etc/lynis/trikusec.crt` for Lynis client use only (not added to system-wide trust store). Lynis is configured to use this certificate via `upload-options=--cacert`.
 - **Dependencies**: Installs required packages (Lynis, etc.).
 - **Configuration**: Configures the Lynis custom profile (`custom.prf`) with the correct server URL and license key.
 - **First Audit**: Performs the first audit with upload enabled (results will appear in TrikuSec).
@@ -54,8 +54,10 @@ If you prefer to configure the client manually, follow these steps.
 ### 1. Handle SSL Certificates
 
 If your TrikuSec server uses self-signed certificates, you have two options:
-*   **Trust the Certificate**: Download the server certificate and add it to the device's trust store.
+*   **Scope to Lynis (Recommended)**: Download the server certificate to `/etc/lynis/trikusec.crt` and configure Lynis to use it via `upload-options=--cacert /etc/lynis/trikusec.crt`. This limits certificate trust to only the Lynis client.
 *   **Ignore Errors**: Configure Lynis to ignore SSL errors by adding `upload-options=--insecure` to the custom profile (see step 3).
+
+**Note**: These two options are mutually exclusive - use only one of them.
 
 ### 2. Install Lynis
 
@@ -81,7 +83,10 @@ license-key=YOUR_LICENSE_KEY
 # Point to the TrikuSec Lynis API server
 upload-server=YOUR_SERVER_ADDRESS
 
-# If using self-signed certs and you didn't add cert to trust store:
+# Option 1: Use scoped certificate (recommended for self-signed certs)
+upload-options=--cacert /etc/lynis/trikusec.crt
+
+# Option 2: Ignore SSL errors (alternative, less secure)
 # upload-options=--insecure
 ```
 


### PR DESCRIPTION
## Summary
This PR implements the improvement suggested in #75 to scope the TrikuSec self-signed certificate to only the Lynis client, instead of installing it system-wide in the CA trust store.

## Changes Made

### Enrollment Script ()
- **Renamed function**: `setup_ssl_certificate()` → `download_ssl_certificate()` for clarity
- **Removed system-wide installation**: No longer copies certificate to `/usr/local/share/ca-certificates/` or runs `update-ca-certificates`
- **Scoped certificate path**: Certificate now saved to `/etc/lynis/trikusec.crt` after Lynis installation
- **Added configuration variable**: `TRIKUSEC_CERT_FINAL=/etc/lynis/trikusec.crt` for maintainability
- **Mutually exclusive options**: Configured Lynis with either `upload-options=--cacert` or `upload-options=--insecure`

### Documentation ()
- Updated "What the script does" section to reflect scoped certificate approach
- Modified manual setup instructions to recommend scoped certificate method
- Updated example `custom.prf` configuration

### Tests ()
- Added comprehensive test: `test_enroll_script_certificate_scoping`
- Verifies certificate path, function rename, and mutually exclusive upload-options
- All 6 enrollment tests passing ✅

## Benefits
- ✅ **Reduced attack surface**: Certificate trust limited to Lynis client only
- ✅ **Better security posture**: System-wide applications don't trust the self-signed cert
- ✅ **Backward compatible**: Existing `--insecure` option behavior preserved
- ✅ **Well tested**: Comprehensive test coverage ensures reliability

## Testing
```bash
docker compose -f docker-compose.dev.yml --profile test run --rm test pytest api/tests.py::TestEnrollScript -v
```
**Result**: ✅ 6/6 tests passing

Fixes #75