### PR TITLE
Fix #85: Lower default High Hardening Index threshold to 60

### DIFF
--- a/docs/usage/policies.md
+++ b/docs/usage/policies.md
@@ -166,7 +166,7 @@ Common fields available in Lynis reports include:
 
 TrikuSec includes pre-installed system rules and a **"Default baseline"** ruleset that provides essential security checks:
 
-- **High Hardening Index** - Requires hardening index > 70
+- **High Hardening Index** - Requires hardening index > 60
 - **No Vulnerable Packages** - Ensures no vulnerable packages detected
 - **Recent Audit** - Requires audit within last 7 days
 

--- a/src/api/migrations/0012_add_creator_and_system_fields.py
+++ b/src/api/migrations/0012_add_creator_and_system_fields.py
@@ -51,8 +51,8 @@ def create_system_user_and_migrate_data(apps, schema_editor):
     system_rules = [
         {
             'name': 'High Hardening Index',
-            'rule_query': 'hardening_index > `70`',
-            'description': 'System requires a hardening index greater than 70',
+            'rule_query': 'hardening_index > `60`',
+            'description': 'System requires a hardening index greater than 60',
             'enabled': True,
             'alert': False,
         },


### PR DESCRIPTION
This PR lowers the default threshold for the 'High Hardening Index' system rule from 70 to 60, as requested in issue #85.

We decided to modify the existing migration file `0012_add_creator_and_system_fields.py` instead of creating a new migration. This means the change will only apply to fresh installations or if the migration is re-run. Existing installations will retain the old threshold unless manually updated.

Changes:
- Modified `src/api/migrations/0012_add_creator_and_system_fields.py`
- Updated `docs/usage/policies.md`