### PR TITLE
Fix enrollment script missing additional packages

### DIFF
--- a/src/api/views.py
+++ b/src/api/views.py
@@ -283,7 +283,7 @@ def enroll_sh(request):
     # Full URL with scheme for Lynis upload-server configuration
     trikusec_lynis_upload_url = f"{parsed_lynis_api_url.scheme}://{parsed_lynis_api_url.netloc}"
     enrollment_settings = EnrollmentSettings.get_settings()
-    additional_packages = enrollment_settings.additional_packages.strip()
+    additional_packages = ' '.join(enrollment_settings.additional_package_names)
     skip_tests = ','.join(enrollment_settings.skip_test_ids)
     plugin_urls = [url.strip() for url in enrollment_settings.plugin_urls if url.strip()]
 


### PR DESCRIPTION
This PR fixes a regression introduced in #87 where additional packages configured via the new `EnrollmentPackage` model were not being included in the generated enrollment script.

The `enroll_sh` view was still accessing the legacy `additional_packages` field on `EnrollmentSettings`. This change updates it to use the `additional_package_names` property, which correctly aggregates packages from both sources.

Fixes regression from #87
Relates to #84