### PR TITLE
Fix timezone issue #89

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -23,7 +23,11 @@ services:
       - DJANGO_SSL_ENABLED=False
       - DJANGO_SSL_CERTFILE=/app/certs/cert.pem
       - DJANGO_SSL_KEYFILE=/app/certs/key.pem
+      - DJANGO_SSL_KEYFILE=/app/certs/key.pem
       - SKIP_COLLECTSTATIC=True
+      - TZ=${TZ:-UTC}
+      - TZ=${TZ:-UTC}
+      - DJANGO_TIME_ZONE=${DJANGO_TIME_ZONE:-UTC}
     ports:
       - 8000:8000
     restart: unless-stopped
@@ -59,6 +63,7 @@ services:
       - SSL_CN=trikusec-lynis-api-dev
       - SKIP_MIGRATIONS=True
       - SKIP_COLLECTSTATIC=True
+      - TZ=${TZ:-UTC}
     restart: unless-stopped
     depends_on:
       trikusec-manager:
@@ -91,6 +96,7 @@ services:
       - TRIKUSEC_LYNIS_API_URL=https://trikusec-lynis-api-dev:8001
       - TRIKUSEC_LYNIS_API_VERIFY_SSL=false
       - TRIKUSEC_LICENSE_KEY=${TRIKUSEC_LICENSE_KEY:-aaaaaaaa-bbbbbbbb-cccccccc}
+      - TZ=${TZ:-UTC}
     working_dir: /app
     command: ["pytest", "-v", "--cov=api", "--cov=frontend", "--cov-report=term-missing"]
     profiles:
@@ -120,6 +126,7 @@ services:
       - PLAYWRIGHT_BROWSERS_PATH=/ms-playwright
       - TRIKUSEC_URL=http://trikusec-manager-dev:8000
       - TRIKUSEC_LYNIS_API_URL=https://trikusec-lynis-api-dev:8001
+      - TZ=${TZ:-UTC}
     working_dir: /app
     command: ["pytest", "-v", "-m", "e2e"]
     profiles:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,6 +45,7 @@ services:
       # Domain-based configuration (automatically configures URLs and allowed hosts)
       - TRIKUSEC_DOMAIN=${TRIKUSEC_DOMAIN}
       - TRIKUSEC_ADMIN_PASSWORD=${TRIKUSEC_ADMIN_PASSWORD:-trikusec}
+      - TZ=${TZ:-UTC}
     expose:
       - "8000"
     restart: unless-stopped
@@ -68,6 +69,7 @@ services:
       - SECRET_KEY=${SECRET_KEY}
       # Domain-based configuration (automatically configures URLs and allowed hosts)
       - TRIKUSEC_DOMAIN=${TRIKUSEC_DOMAIN}
+      - TZ=${TZ:-UTC}
     expose:
       - "8001"
     restart: unless-stopped

--- a/src/api/tests_timezone_repro.py
+++ b/src/api/tests_timezone_repro.py
@@ -1,0 +1,54 @@
+
+import pytest
+from django.utils import timezone
+from datetime import datetime, timedelta
+from api.utils.lynis_report import LynisReport
+
+class TestTimezoneIssue:
+    def test_future_report_time_reproduction(self):
+        """
+        Reproduce the issue where a report with local time (e.g. CET) is interpreted as UTC,
+        resulting in a future timestamp.
+        """
+        # 1. Setup: Assume Server is UTC (standard Django setting)
+        # and current time is T.
+        now_utc = timezone.now()
+        
+        # 2. Simulate a device in CET (UTC+1) sending a report.
+        # If it's 12:00 UTC, it's 13:00 CET.
+        # The device writes "2023-XX-XX 13:00:00" (naive) in the report.
+        cet_offset = timedelta(hours=1)
+        device_time_cet = now_utc + cet_offset
+        naive_report_time_str = device_time_cet.strftime('%Y-%m-%d %H:%M:%S')
+        
+        print(f"\nReal UTC Now: {now_utc}")
+        print(f"Device Report Time (CET, Naive): {naive_report_time_str}")
+        
+        # 3. Parse the report
+        report_content = f"report_datetime_end={naive_report_time_str}"
+        report = LynisReport(report_content)
+        parsed_dt = report.get('report_datetime_end')
+        
+        print(f"Parsed Datetime (Server interpreted): {parsed_dt}")
+        
+        # 4. Verification
+        # The parsed time should be treated as UTC by default if naive.
+        # So "13:00" becomes "13:00 UTC".
+        # "13:00 UTC" is 1 hour ahead of "12:00 UTC" (Real Now).
+        # So parsed_dt > now_utc
+        
+        # We expect this to PASS now that the fix is implemented.
+        # The timestamp should be clamped to now_utc (or very close to it).
+        
+        # Allow a small delta for execution time (e.g. 1 second)
+        time_diff = parsed_dt - now_utc
+        print(f"Time Difference (parsed - now): {time_diff}")
+        
+        assert parsed_dt <= now_utc + timedelta(seconds=1), "Fix Failed: Parsed time is still significantly in the future!"
+        
+        # It should be clamped to "now", so it shouldn't be too far in the past either 
+        # (unless "now" moved forward significantly during execution)
+        assert parsed_dt >= now_utc - timedelta(seconds=5), "Fix Failed: Parsed time is too far in the past (clamping error?)"
+        
+        print("SUCCESS: Future timestamp was clamped to server time.")
+

--- a/src/api/utils/lynis_report.py
+++ b/src/api/utils/lynis_report.py
@@ -372,6 +372,14 @@ class LynisReport:
             if timezone.is_naive(parsed_datetime):
                 parsed_datetime = timezone.make_aware(parsed_datetime, timezone.get_current_timezone())
             
+            # Fix for Issue #89: Clamp future timestamps to now
+            # Naive timestamps from Lynis (local time) might be interpreted as UTC,
+            # resulting in future times if the device is ahead of UTC.
+            now = timezone.now()
+            if parsed_datetime > now:
+                logging.warning(f'Report timestamp {parsed_datetime} is in the future (server time: {now}). Clamping to server time.')
+                parsed_datetime = now
+
             return parsed_datetime
 
         logging.debug('Unsupported report_datetime_end type: %s', type(value))

--- a/src/trikusec/settings/base.py
+++ b/src/trikusec/settings/base.py
@@ -187,7 +187,7 @@ AUTH_PASSWORD_VALIDATORS = [
 
 LANGUAGE_CODE = 'en-us'
 
-TIME_ZONE = 'UTC'
+TIME_ZONE = os.environ.get('DJANGO_TIME_ZONE', os.environ.get('TZ', 'UTC'))
 
 USE_I18N = True
 


### PR DESCRIPTION
Fixes #89. Configures TZ environment variable for Docker containers and clamps future report timestamps to server time.