### PR TITLE
Fix OS Distribution widget showing version twice

### DIFF
--- a/src/frontend/templates/dashboard.html
+++ b/src/frontend/templates/dashboard.html
@@ -99,7 +99,7 @@
                 <div class="flex items-center">
                     <div class="w-32 flex items-center flex-shrink-0">
                         <span class="mr-1">{{ entry.distro|distro_icon }}</span>
-                        <span class="text-sm text-gray-700 truncate" title="{{ entry.distro }} {{ entry.distro_version|default:'' }}">{{ entry.distro }} {{ entry.distro_version|default:'' }}</span>
+                        <span class="text-sm text-gray-700 truncate" title="{{ entry.distro }}">{{ entry.distro }}</span>
                     </div>
                     <div class="flex-1 mx-3">
                         <div class="w-full bg-gray-200 rounded-full h-4">


### PR DESCRIPTION
## Summary

Fixes #103

The OS Distribution widget was displaying the version number twice (e.g. "Debian 12 12") because the template rendered both `entry.distro` (from `os_fullname`) and `entry.distro_version` (from `os_version`). The full name already includes the version.

## Change

- Display only `entry.distro` in the dashboard widget and its tooltip.
- No backend changes; `distro` already holds the full distribution name.
