### PR TITLE
Upgrade Django to 5.2.11 LTS

### DIFF
--- a/src/requirements-api.txt
+++ b/src/requirements-api.txt
@@ -1,5 +1,5 @@
 # API dependencies
-Django==5.2.1
+Django==5.2.11
 pyyaml==6.0.2
 jmespath>=1.0.1
 psycopg2-binary==2.9.10


### PR DESCRIPTION
## Summary

This PR upgrades Django from 5.2.1 to 5.2.11 LTS (Long-Term Support until April 2028) 