### PR TITLE
fix: refresh compliance after ruleset assignment

### DIFF
--- a/src/frontend/tests.py
+++ b/src/frontend/tests.py
@@ -403,6 +403,52 @@ class TestDeviceDelete:
 
 
 @pytest.mark.django_db
+class TestDeviceUpdateCompliance:
+    """Tests for compliance refresh when updating device rulesets."""
+
+    def test_assigning_non_compliant_ruleset_updates_device_status(self, test_user, test_device, sample_lynis_report):
+        from api.models import PolicyRule, PolicyRuleset
+
+        client = Client()
+        client.force_login(test_user)
+
+        FullReport.objects.create(device=test_device, full_report=sample_lynis_report)
+
+        rule = PolicyRule.objects.create(
+            name='Hardening over 100',
+            rule_query='hardening_index > `100`',
+            description='Intentionally failing rule for regression coverage',
+            enabled=True,
+        )
+        ruleset = PolicyRuleset.objects.create(
+            name='Strict Baseline',
+            description='Ruleset that should fail for sample report',
+        )
+        ruleset.rules.add(rule)
+
+        assert test_device.compliant is True
+
+        response = client.post(
+            reverse('device_update', kwargs={'device_id': test_device.id}),
+            data={'rulesets': [str(ruleset.id)]},
+        )
+
+        assert response.status_code == 302
+
+        test_device.refresh_from_db()
+        assert test_device.compliant is False
+        assert test_device.rulesets.filter(id=ruleset.id).exists()
+
+        compliance_event = DeviceEvent.objects.filter(
+            device=test_device,
+            event_type='compliance_changed',
+        ).first()
+        assert compliance_event is not None
+        assert compliance_event.metadata['old_status'] == 'Compliant'
+        assert compliance_event.metadata['new_status'] == 'Non-Compliant'
+
+
+@pytest.mark.django_db
 class TestActivityView:
     """Tests for the activity timeline view."""
 

--- a/src/frontend/views.py
+++ b/src/frontend/views.py
@@ -534,6 +534,16 @@ def device_update(request, device_id):
             logging.debug('Selected rulesets: %s', selected_rulesets)
             device.rulesets.set(selected_rulesets)
             form.save()
+
+            # Recalculate compliance immediately when rulesets change
+            latest_report = FullReport.objects.filter(device=device).order_by('-created_at').first()
+            if latest_report:
+                parsed_report = LynisReport(latest_report.full_report).get_parsed_report()
+                if isinstance(parsed_report, dict) and parsed_report:
+                    update_device_compliance(device, parsed_report)
+                else:
+                    logging.warning('Skipping compliance update for device %s: latest report could not be parsed', device.id)
+
             # Return to the referer page
             return safe_redirect(request, 'device_detail', device_id=device_id)
         else:


### PR DESCRIPTION
## Summary
- recalculate device compliance in `device_update` right after rulesets are changed, using the latest stored Lynis report
- persist compliance changes through the existing `update_device_compliance` path so the host badge and compliance events stay in sync with policy status
- add a regression test that verifies assigning a failing ruleset updates the host to non-compliant and records a compliance change event

## Testing
- docker compose -f docker-compose.dev.yml --profile test run --rm test pytest frontend/tests.py::TestDeviceUpdateCompliance::test_assigning_non_compliant_ruleset_updates_device_status -v

Closes #116