### PR TITLE
Add device unassign action in ruleset detail view

### DIFF
--- a/src/frontend/templates/policy/ruleset_detail.html
+++ b/src/frontend/templates/policy/ruleset_detail.html
@@ -165,12 +165,22 @@
                                     {% endif %}
                                 </td>
                                 <td class="py-3 px-6 text-left">
-                                    <a href="{% url 'device_detail' device_id=device.id %}" class="text-gray-600 hover:text-gray-800" title="View">
-                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"></path>
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
-                                        </svg>
-                                    </a>
+                                    <div class="flex items-center gap-3">
+                                        <a href="{% url 'device_detail' device_id=device.id %}" class="text-gray-600 hover:text-gray-800" title="View">
+                                            <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"></path>
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                                            </svg>
+                                        </a>
+                                        <form method="post" action="{% url 'ruleset_remove_device' ruleset_id=ruleset.id device_id=device.id %}" class="inline">
+                                            {% csrf_token %}
+                                            <button type="submit" class="text-red-600 hover:text-red-800" title="Remove ruleset from device" onclick="return confirm('Remove this ruleset from {{ device.hostname|default:device.hostid|escapejs }}?');">
+                                                <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                                    <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M19.5 12h-15"></path>
+                                                </svg>
+                                            </button>
+                                        </form>
+                                    </div>
                                 </td>
                             </tr>
                             {% endfor %}
@@ -196,4 +206,3 @@
     <script src="{% static 'js/policies.js' %}"></script>
     <script src="{% static 'js/rules.js' %}"></script>
 {% endblock %}
-

--- a/src/frontend/tests.py
+++ b/src/frontend/tests.py
@@ -449,6 +449,72 @@ class TestDeviceUpdateCompliance:
 
 
 @pytest.mark.django_db
+class TestRulesetRemoveDevice:
+    """Tests for removing device assignments from the ruleset detail page."""
+
+    def test_remove_device_from_ruleset_success(self, test_user, test_device):
+        from api.models import PolicyRuleset
+
+        client = Client()
+        client.force_login(test_user)
+
+        ruleset = PolicyRuleset.objects.create(
+            name='Baseline Ruleset',
+            description='Ruleset for remove-assignment flow',
+            created_by=test_user,
+            is_system=False,
+        )
+        test_device.rulesets.add(ruleset)
+
+        response = client.post(
+            reverse('ruleset_remove_device', kwargs={'ruleset_id': ruleset.id, 'device_id': test_device.id})
+        )
+
+        assert response.status_code == 302
+        assert response.url == reverse('ruleset_detail', kwargs={'ruleset_id': ruleset.id})
+        assert not test_device.rulesets.filter(id=ruleset.id).exists()
+
+    def test_remove_device_from_ruleset_get_method(self, test_user, test_device):
+        from api.models import PolicyRuleset
+
+        client = Client()
+        client.force_login(test_user)
+
+        ruleset = PolicyRuleset.objects.create(
+            name='Baseline Ruleset',
+            created_by=test_user,
+            is_system=False,
+        )
+        test_device.rulesets.add(ruleset)
+
+        response = client.get(
+            reverse('ruleset_remove_device', kwargs={'ruleset_id': ruleset.id, 'device_id': test_device.id})
+        )
+
+        assert response.status_code == 405
+        assert response.content == b'Method not allowed'
+
+    def test_ruleset_detail_shows_remove_action(self, test_user, test_device):
+        from api.models import PolicyRuleset
+
+        client = Client()
+        client.force_login(test_user)
+
+        ruleset = PolicyRuleset.objects.create(
+            name='Baseline Ruleset',
+            created_by=test_user,
+            is_system=False,
+        )
+        test_device.rulesets.add(ruleset)
+
+        response = client.get(reverse('ruleset_detail', kwargs={'ruleset_id': ruleset.id}))
+
+        assert response.status_code == 200
+        expected_url = reverse('ruleset_remove_device', kwargs={'ruleset_id': ruleset.id, 'device_id': test_device.id})
+        assert expected_url.encode() in response.content
+
+
+@pytest.mark.django_db
 class TestActivityView:
     """Tests for the activity timeline view."""
 

--- a/src/frontend/urls.py
+++ b/src/frontend/urls.py
@@ -26,6 +26,7 @@ urlpatterns = [
     # Backward compatibility redirect
     path('rulesets/', views.policy_list, name='ruleset_list'),
     path('ruleset/<int:ruleset_id>/', views.ruleset_detail, name='ruleset_detail'),
+    path('ruleset/<int:ruleset_id>/device/<int:device_id>/remove/', views.ruleset_remove_device, name='ruleset_remove_device'),
     path('ruleset/create/', views.ruleset_create, name='ruleset_create'),
     path('ruleset/<int:ruleset_id>/edit/', views.ruleset_update, name='ruleset_update'),
     path('ruleset/<int:ruleset_id>/delete/', views.ruleset_delete, name='ruleset_delete'),

--- a/src/frontend/views.py
+++ b/src/frontend/views.py
@@ -945,6 +945,31 @@ def ruleset_detail(request, ruleset_id):
     return render(request, 'policy/ruleset_detail.html', context)
 
 
+@login_required
+@csrf_protect
+def ruleset_remove_device(request, ruleset_id, device_id):
+    """Remove a device from a ruleset from the ruleset detail view."""
+    if request.method != 'POST':
+        return HttpResponse('Method not allowed', status=405)
+
+    ruleset = get_object_or_404(PolicyRuleset, id=ruleset_id)
+    device = get_object_or_404(Device, id=device_id, rulesets=ruleset)
+
+    device.rulesets.remove(ruleset)
+
+    latest_report = FullReport.objects.filter(device=device).order_by('-created_at').first()
+    if latest_report:
+        parsed_report = LynisReport(latest_report.full_report).get_parsed_report()
+        if isinstance(parsed_report, dict) and parsed_report:
+            update_device_compliance(device, parsed_report)
+        else:
+            logging.warning('Skipping compliance update for device %s: latest report could not be parsed', device.id)
+
+    device_name = device.hostname or device.hostid
+    messages.success(request, f'Ruleset "{ruleset.name}" removed from device "{device_name}".')
+    return redirect('ruleset_detail', ruleset_id=ruleset.id)
+
+
 @csrf_protect
 @login_required
 def ruleset_update(request, ruleset_id):


### PR DESCRIPTION
## Summary
- add a remove/unassign action for each device listed in the ruleset detail page (`/ruleset/<id>/`)
- implement a protected POST endpoint to detach a device from a ruleset and recalculate device compliance using the latest report
- add frontend tests to cover successful removal, method restrictions, and rendering of the new action

## Testing
- docker compose -f docker-compose.dev.yml --profile test run --rm test

Closes #119