### PR TITLE
Add device pass/fail status section to rule detail

### DIFF
--- a/src/frontend/templates/policy/rule_detail.html
+++ b/src/frontend/templates/policy/rule_detail.html
@@ -78,7 +78,7 @@
         </div>
 
         <!-- Rulesets Using This Rule -->
-        <div class="bg-white shadow-md rounded-lg overflow-hidden">
+        <div class="bg-white shadow-md rounded-lg overflow-hidden mb-6">
             <div class="p-6">
                 <h2 class="text-xl font-semibold mb-4">Rulesets Using This Rule</h2>
                 {% if rulesets %}
@@ -123,6 +123,64 @@
                     </table>
                 {% else %}
                     <p class="text-gray-500">This rule is not used in any rulesets yet.</p>
+                {% endif %}
+            </div>
+        </div>
+
+        <!-- Devices Using This Rule -->
+        <div class="bg-white shadow-md rounded-lg overflow-hidden">
+            <div class="p-6">
+                <h2 class="text-xl font-semibold mb-4">Devices Using This Rule</h2>
+                {% if configured_devices %}
+                    <table class="min-w-full">
+                        <thead>
+                            <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
+                                <th class="py-3 px-6 text-left">Device</th>
+                                <th class="py-3 px-6 text-left">Host ID</th>
+                                <th class="py-3 px-6 text-left">Via Rulesets</th>
+                                <th class="py-3 px-6 text-left">Last Report</th>
+                                <th class="py-3 px-6 text-left">Status</th>
+                                <th class="py-3 px-6 text-left">Actions</th>
+                            </tr>
+                        </thead>
+                        <tbody class="text-gray-600 text-sm font-light">
+                            {% for entry in configured_devices %}
+                            <tr class="border-b border-gray-200 hover:bg-gray-100">
+                                <td class="py-3 px-6 text-left font-medium text-gray-800">
+                                    {{ entry.device.hostname|default:entry.device.hostid }}
+                                </td>
+                                <td class="py-3 px-6 text-left">{{ entry.device.hostid }}</td>
+                                <td class="py-3 px-6 text-left">{{ entry.rulesets|join:", " }}</td>
+                                <td class="py-3 px-6 text-left">
+                                    {% if entry.last_report_at %}
+                                        {{ entry.last_report_at|date:"Y-m-d H:i" }}
+                                    {% else %}
+                                        -
+                                    {% endif %}
+                                </td>
+                                <td class="py-3 px-6 text-left">
+                                    {% if entry.status == 'pass' %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-green-100 text-green-800">Pass</span>
+                                    {% elif entry.status == 'fail' %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-red-100 text-red-800">Fail</span>
+                                    {% else %}
+                                        <span class="inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium bg-gray-100 text-gray-800">{{ entry.status_label }}</span>
+                                    {% endif %}
+                                </td>
+                                <td class="py-3 px-6 text-left">
+                                    <a href="{% url 'device_detail' device_id=entry.device.id %}" class="text-gray-600 hover:text-gray-800" title="View device">
+                                        <svg class="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M2.036 12.322a1.012 1.012 0 010-.639C3.423 7.51 7.36 4.5 12 4.5c4.638 0 8.573 3.007 9.963 7.178.07.207.07.431 0 .639C20.577 16.49 16.64 19.5 12 19.5c-4.638 0-8.573-3.007-9.963-7.178z"></path>
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M15 12a3 3 0 11-6 0 3 3 0 016 0z"></path>
+                                        </svg>
+                                    </a>
+                                </td>
+                            </tr>
+                            {% endfor %}
+                        </tbody>
+                    </table>
+                {% else %}
+                    <p class="text-gray-500">No devices currently have this rule assigned via a ruleset.</p>
                 {% endif %}
             </div>
         </div>

--- a/src/frontend/tests.py
+++ b/src/frontend/tests.py
@@ -1131,6 +1131,64 @@ class TestRuleDetailView:
         assert response.status_code == 302
         assert '/login' in response.url
 
+    def test_rule_detail_shows_configured_devices_and_status(self, test_user, test_device, sample_lynis_report):
+        """Rule detail should include devices configured with this rule and pass/fail/no-report status."""
+        from api.models import PolicyRule, PolicyRuleset
+
+        client = Client()
+        client.force_login(test_user)
+
+        rule = PolicyRule.objects.create(
+            name='Hardening over 60',
+            description='Test device status visibility',
+            rule_query='hardening_index > `60`',
+            enabled=True,
+            created_by=test_user,
+        )
+        ruleset = PolicyRuleset.objects.create(
+            name='Baseline',
+            description='Baseline ruleset',
+            created_by=test_user,
+        )
+        ruleset.rules.add(rule)
+
+        passing_device = test_device
+        passing_device.hostname = 'pass-host'
+        passing_device.save()
+
+        failing_device = Device.objects.create(
+            licensekey=test_device.licensekey,
+            hostid='fail-host-id',
+            hostid2='fail-host-id2',
+            hostname='fail-host',
+            compliant=True,
+        )
+        no_report_device = Device.objects.create(
+            licensekey=test_device.licensekey,
+            hostid='noreport-host-id',
+            hostid2='noreport-host-id2',
+            hostname='noreport-host',
+            compliant=True,
+        )
+
+        passing_device.rulesets.add(ruleset)
+        failing_device.rulesets.add(ruleset)
+        no_report_device.rulesets.add(ruleset)
+
+        FullReport.objects.create(device=passing_device, full_report=sample_lynis_report)
+        failing_report = sample_lynis_report.replace('hardening_index=65', 'hardening_index=10')
+        FullReport.objects.create(device=failing_device, full_report=failing_report)
+
+        response = client.get(reverse('rule_detail', kwargs={'rule_id': rule.id}))
+
+        assert response.status_code == 200
+        configured_devices = response.context['configured_devices']
+
+        status_by_host = {entry['device'].hostname: entry['status'] for entry in configured_devices}
+        assert status_by_host['pass-host'] == 'pass'
+        assert status_by_host['fail-host'] == 'fail'
+        assert status_by_host['noreport-host'] == 'unknown'
+
 
 @pytest.mark.django_db
 class TestPolicyRuleFormValidation:

--- a/src/frontend/views.py
+++ b/src/frontend/views.py
@@ -1221,12 +1221,49 @@ def rule_list(request):
 
 @login_required
 def rule_detail(request, rule_id):
-    """Rule detail view: show rule info, rulesets using it"""
+    """Rule detail view: show rule info, rulesets using it, and device evaluation status."""
     rule = get_object_or_404(PolicyRule, id=rule_id)
-    
+
     # Get rulesets using this rule (reverse relationship)
     rulesets = rule.policyruleset_set.all().order_by('name')
-    
+
+    # Get devices that have this rule configured via at least one assigned ruleset
+    configured_devices_qs = Device.objects.filter(rulesets__rules=rule).distinct().order_by('hostname', 'hostid')
+    configured_devices = []
+
+    for device in configured_devices_qs:
+        latest_report = FullReport.objects.filter(device=device).order_by('-created_at').first()
+        matching_rulesets = list(device.rulesets.filter(rules=rule).order_by('name').values_list('name', flat=True))
+
+        status = 'unknown'
+        status_label = 'No report'
+        last_report_at = latest_report.created_at if latest_report else None
+
+        if latest_report:
+            parsed_report = LynisReport(latest_report.full_report).get_parsed_report()
+            if isinstance(parsed_report, dict) and parsed_report:
+                evaluation_result = rule.evaluate(parsed_report)
+                if evaluation_result is True:
+                    status = 'pass'
+                    status_label = 'Pass'
+                elif evaluation_result is False:
+                    status = 'fail'
+                    status_label = 'Fail'
+                else:
+                    status = 'unknown'
+                    status_label = 'Unknown'
+            else:
+                status = 'unknown'
+                status_label = 'Unknown'
+
+        configured_devices.append({
+            'device': device,
+            'status': status,
+            'status_label': status_label,
+            'rulesets': matching_rulesets,
+            'last_report_at': last_report_at,
+        })
+
     # Serialize rule for JavaScript
     rule_data = {
         'id': rule.id,
@@ -1238,13 +1275,14 @@ def rule_detail(request, rule_id):
         'created_at': rule.created_at.isoformat(),
         'updated_at': rule.updated_at.isoformat(),
     }
-    
+
     context = {
         'rule': rule,
         'rulesets': rulesets,  # Rulesets using this rule
+        'configured_devices': configured_devices,
         'rule_json': json.dumps(rule_data),
     }
-    
+
     return render(request, 'policy/rule_detail.html', context)
 
 @login_required


### PR DESCRIPTION
## Summary\n- add a new "Devices Using This Rule" section on \n- list devices configured via rulesets that include the rule\n- show per-device evaluation status (Pass/Fail/Unknown) using latest report\n- include linked rulesets and last report timestamp\n\n## Testing\n- docker compose -f docker-compose.dev.yml --profile test run --rm test pytest frontend/tests.py::TestRuleDetailView -v