### PR TITLE
Mark compliance as Unknown when no ruleset is assigned

### DIFF
--- a/src/api/admin.py
+++ b/src/api/admin.py
@@ -69,6 +69,8 @@ class DeviceAdmin(admin.ModelAdmin):
     
     @admin.display(description='Status')
     def compliance_status(self, obj):
+        if not obj.rulesets.exists():
+            return format_html('<span style="color: gray;">? Unknown</span>')
         if obj.compliant:
             return format_html('<span style="color: green;">✓ Compliant</span>')
         return format_html('<span style="color: red;">✗ Non-compliant</span>')

--- a/src/frontend/templates/dashboard.html
+++ b/src/frontend/templates/dashboard.html
@@ -33,7 +33,7 @@
             <div class="flex items-center justify-between">
                 <div>
                     <p class="text-sm font-medium text-gray-500 uppercase tracking-wide">Compliant</p>
-                    <p class="text-3xl font-bold text-gray-900 mt-1">{{ compliant_count }}<span class="text-lg text-gray-400 font-normal">/{{ total_devices }}</span></p>
+                    <p class="text-3xl font-bold text-gray-900 mt-1">{{ compliant_count }}<span class="text-lg text-gray-400 font-normal">/{{ assessed_devices_count }}</span></p>
                 </div>
                 <div class="p-3 bg-green-50 rounded-full">
                     <svg class="w-6 h-6 text-green-500" fill="none" viewBox="0 0 24 24" stroke="currentColor">
@@ -45,7 +45,7 @@
                 <div class="w-full bg-gray-200 rounded-full h-2">
                     <div class="h-2 rounded-full {% if compliance_pct >= 80 %}bg-green-500{% elif compliance_pct >= 50 %}bg-yellow-500{% else %}bg-red-500{% endif %}" style="width: {{ compliance_pct }}%"></div>
                 </div>
-                <p class="text-xs text-gray-500 mt-1">{{ compliance_pct }}% compliance rate</p>
+                <p class="text-xs text-gray-500 mt-1">{{ compliance_pct }}% compliance rate{% if unknown_count %} ({{ unknown_count }} unknown){% endif %}</p>
             </div>
         </div>
 

--- a/src/frontend/templates/device/device_pdf.html
+++ b/src/frontend/templates/device/device_pdf.html
@@ -107,9 +107,13 @@
         </div>
         <div class="info-item">
             <span class="info-label">Compliance:</span>
+            {% if not has_rulesets %}
+            <span class="info-value">Unknown</span>
+            {% else %}
             <span class="info-value {% if device.compliant %}compliant{% else %}non-compliant{% endif %}">
                 {% if device.compliant %}Compliant{% else %}Non-compliant{% endif %}
             </span>
+            {% endif %}
         </div>
         <div class="info-item">
             <span class="info-label">IP Address:</span>

--- a/src/frontend/templates/device_detail.html
+++ b/src/frontend/templates/device_detail.html
@@ -62,7 +62,9 @@
                 <div class="grid grid-cols-2 w-96 space-y-2">
                     <div class="text-left text-gray-600 mt-2">Compliance</div>
                     <div class="text-left w-80 text-gray-900 font-medium">:
-                        {% if device.compliant %}
+                        {% if not has_rulesets %}
+                        <span class="ml-2 bg-gray-200 text-gray-700 py-1 px-3 rounded-full text-xs">Unknown</span>
+                        {% elif device.compliant %}
                         <span class="ml-2 bg-green-200 text-green-600 py-1 px-3 rounded-full text-xs">Compliant</span>
                         {% else %}
                         <span class="ml-2 bg-red-200 text-red-600 py-1 px-3 rounded-full text-xs">Non-compliant</span>

--- a/src/frontend/templates/device_list.html
+++ b/src/frontend/templates/device_list.html
@@ -191,7 +191,9 @@
                             </div>
                         </td>
                         <td class="py-3 px-6 text-left">
-                            {% if device.compliant %}
+                            {% if device.ruleset_count == 0 %}
+                            <span class="bg-gray-200 text-gray-700 py-1 px-3 rounded-full text-xs">Unknown</span>
+                            {% elif device.compliant %}
                             <span class="bg-green-200 text-green-600 py-1 px-3 rounded-full text-xs">Compliant</span>
                             {% else %}
                             <span class="bg-red-200 text-red-600 py-1 px-3 rounded-full text-xs">Not Compliant</span>

--- a/src/frontend/tests.py
+++ b/src/frontend/tests.py
@@ -303,6 +303,33 @@ class TestDeviceListPagination:
 
 
 @pytest.mark.django_db
+class TestDeviceComplianceUnknownStatus:
+    """Devices without assigned rulesets should be shown as Unknown."""
+
+    def test_device_list_shows_unknown_when_no_ruleset(self, test_user, test_device, sample_lynis_report):
+        client = Client()
+        client.force_login(test_user)
+
+        FullReport.objects.create(device=test_device, full_report=sample_lynis_report)
+
+        response = client.get(reverse('device_list'))
+
+        assert response.status_code == 200
+        assert b'Unknown' in response.content
+
+    def test_device_detail_shows_unknown_when_no_ruleset(self, test_user, test_device, sample_lynis_report):
+        client = Client()
+        client.force_login(test_user)
+
+        FullReport.objects.create(device=test_device, full_report=sample_lynis_report)
+
+        response = client.get(reverse('device_detail', kwargs={'device_id': test_device.id}))
+
+        assert response.status_code == 200
+        assert b'Unknown' in response.content
+
+
+@pytest.mark.django_db
 class TestDeviceDelete:
     """Tests for the device_delete endpoint."""
 
@@ -1294,8 +1321,9 @@ class TestDashboardView:
         assert response.status_code == 200
         assert 'total_devices' in response.context
         assert response.context['total_devices'] == 1
-        assert response.context['compliant_count'] == 1
+        assert response.context['compliant_count'] == 0
         assert response.context['non_compliant_count'] == 0
+        assert response.context['unknown_count'] == 1
 
     def test_dashboard_requires_authentication(self):
         """Dashboard should redirect unauthenticated users to login."""
@@ -1309,20 +1337,41 @@ class TestDashboardView:
     def test_dashboard_compliance_stats(self, test_user, test_license_key):
         """Dashboard should show correct compliance statistics."""
         from conftest import DeviceFactory
+        from api.models import PolicyRule, PolicyRuleset
 
         client = Client()
         client.force_login(test_user)
 
+        # Create one shared ruleset so devices are considered assessed
+        rule = PolicyRule.objects.create(
+            name='Dashboard marker rule',
+            description='Used for dashboard counting tests',
+            rule_query='hardening_index > `0`',
+            enabled=True,
+            created_by=test_user,
+        )
+        ruleset = PolicyRuleset.objects.create(
+            name='Dashboard Test Ruleset',
+            description='Test ruleset',
+            created_by=test_user,
+        )
+        ruleset.rules.add(rule)
+
         # Create 3 compliant and 2 non-compliant devices
+        devices = []
         for i in range(3):
-            DeviceFactory(licensekey=test_license_key, compliant=True)
+            devices.append(DeviceFactory(licensekey=test_license_key, compliant=True))
         for i in range(2):
-            DeviceFactory(licensekey=test_license_key, compliant=False, warnings=3)
+            devices.append(DeviceFactory(licensekey=test_license_key, compliant=False, warnings=3))
+        for device in devices:
+            device.rulesets.add(ruleset)
 
         response = client.get(reverse('dashboard'))
 
         assert response.status_code == 200
         assert response.context['total_devices'] == 5
+        assert response.context['assessed_devices_count'] == 5
+        assert response.context['unknown_count'] == 0
         assert response.context['compliant_count'] == 3
         assert response.context['non_compliant_count'] == 2
         assert response.context['compliance_pct'] == 60

--- a/src/frontend/views.py
+++ b/src/frontend/views.py
@@ -119,9 +119,12 @@ def dashboard(request):
         return redirect('onboarding')
 
     # --- Summary cards ---
-    compliant_count = devices.filter(compliant=True).count()
-    non_compliant_count = total_devices - compliant_count
-    compliance_pct = round(compliant_count * 100 / total_devices) if total_devices else 0
+    assessed_devices = devices.filter(rulesets__isnull=False).distinct()
+    assessed_devices_count = assessed_devices.count()
+    compliant_count = assessed_devices.filter(compliant=True).count()
+    non_compliant_count = assessed_devices.filter(compliant=False).count()
+    unknown_count = total_devices - assessed_devices_count
+    compliance_pct = round(compliant_count * 100 / assessed_devices_count) if assessed_devices_count else 0
     total_warnings = devices.aggregate(total=Sum('warnings'))['total'] or 0
 
     # Average hardening index (requires parsing reports)
@@ -233,6 +236,8 @@ def dashboard(request):
         'compliant_count': compliant_count,
         'non_compliant_count': non_compliant_count,
         'compliance_pct': compliance_pct,
+        'assessed_devices_count': assessed_devices_count,
+        'unknown_count': unknown_count,
         'total_warnings': total_warnings,
         'avg_hardening': avg_hardening,
         'os_distribution': os_distribution,
@@ -398,7 +403,7 @@ def onboarding(request):
 @login_required
 def device_list(request):
     """Device list view: show all devices"""
-    devices_qs = Device.objects.all()
+    devices_qs = Device.objects.annotate(ruleset_count=Count('rulesets', distinct=True))
     has_devices = devices_qs.exists()
     
     # Only process compliance if devices exist
@@ -441,7 +446,7 @@ def device_list(request):
     # If sorting by hardening_index, we need to extract it first and sort in Python
     elif sort_field == 'hardening_index':
         # Get all devices first
-        devices = list(Device.objects.all())
+        devices = list(Device.objects.annotate(ruleset_count=Count('rulesets', distinct=True)))
         
         # Extract hardening_index from latest report for each device
         for device in devices:
@@ -466,7 +471,7 @@ def device_list(request):
             order_by = f'-{sort_field}'
         
         # Order devices by selected field
-        devices = Device.objects.all().order_by(order_by)
+        devices = Device.objects.annotate(ruleset_count=Count('rulesets', distinct=True)).order_by(order_by)
         
         # Extract hardening_index from latest report for each device (for display)
         devices_list = list(devices)
@@ -564,6 +569,7 @@ def device_detail(request, device_id):
         'device': device,
         'report': report,
         'evaluated_rulesets': evaluated_rulesets,
+        'has_rulesets': device.rulesets.exists(),
         'rulesets': policy_rulesets,
         'all_rules': all_rules,  # For rule selection sidebar template
         'rulesets_json': json.dumps(rulesets_data),
@@ -669,6 +675,7 @@ def device_export_pdf(request, device_id):
         'device': device,
         'report': report,
         'evaluated_rulesets': evaluated_rulesets,
+        'has_rulesets': device.rulesets.exists(),
         'generated_at': datetime.now(),
     }, request=request)
     


### PR DESCRIPTION
## Summary
- show **Unknown** compliance status for devices without assigned rulesets
- apply Unknown status in device list, device detail, PDF export, and Django admin
- adjust dashboard compliance counters to use assessed devices only
- include unknown count in dashboard compliance subtitle
- add/update tests for unknown status and dashboard counters

## Testing
- docker compose -f docker-compose.dev.yml --profile test run --rm test pytest frontend/tests.py::TestDeviceComplianceUnknownStatus frontend/tests.py::TestDashboardView -v