### PR TITLE
Fix Ubuntu debsecan source summary export and urgency filtering

### DIFF
--- a/trikusec-lynis-plugin/plugin_trikusec_phase1
+++ b/trikusec-lynis-plugin/plugin_trikusec_phase1
@@ -232,7 +232,7 @@
         DEBSECAN_SOURCE_URL=""
         case "${DISTRO_ID} ${DISTRO_ID_LIKE}" in
             *ubuntu*)
-                DEBSECAN_SOURCE_URL="https://trikusec.github.io/ubt2dsa/"
+                DEBSECAN_SOURCE_URL="https://trikusec.github.io/ubt2dsa/release/1/"
                 ;;
         esac
 
@@ -241,35 +241,28 @@
         fi
 
         # Collect debsecan output with robust fallbacks.
-        # Always use --format summary, then keep only "high urgency" entries.
+        # Always use --format summary, then keep high-urgency entries.
         DEBSECAN_OUTPUT=""
 
-        if [ ! "${DEBSECAN_SOURCE_URL}" = "" ]; then
+        # For Ubuntu custom source, prefer explicit suite first.
+        if [ ! "${DEBSECAN_SOURCE_URL}" = "" ] && [ ! "${DISTRO_CODENAME}" = "" ]; then
+            DEBSECAN_OUTPUT=$(debsecan --suite "${DISTRO_CODENAME}" --source "${DEBSECAN_SOURCE_URL}" --format summary 2>/dev/null)
+        fi
+
+        if [ "${DEBSECAN_OUTPUT}" = "" ] && [ ! "${DEBSECAN_SOURCE_URL}" = "" ]; then
             DEBSECAN_OUTPUT=$(debsecan --source "${DEBSECAN_SOURCE_URL}" --format summary 2>/dev/null)
-        else
-            DEBSECAN_OUTPUT=$(debsecan --format summary 2>/dev/null)
         fi
 
         if [ "${DEBSECAN_OUTPUT}" = "" ] && [ ! "${DISTRO_CODENAME}" = "" ]; then
-            if [ ! "${DEBSECAN_SOURCE_URL}" = "" ]; then
-                DEBSECAN_OUTPUT=$(debsecan --source "${DEBSECAN_SOURCE_URL}" --suite "${DISTRO_CODENAME}" --format summary 2>/dev/null)
-            else
-                DEBSECAN_OUTPUT=$(debsecan --suite "${DISTRO_CODENAME}" --format summary 2>/dev/null)
-            fi
-        fi
-
-        # Fallback: on some Ubuntu installations the custom source can return no data.
-        # If so, retry using the distro's default debsecan source.
-        if [ "${DEBSECAN_OUTPUT}" = "" ] && [ ! "${DEBSECAN_SOURCE_URL}" = "" ]; then
-            DEBSECAN_OUTPUT=$(debsecan --format summary 2>/dev/null)
-        fi
-
-        if [ "${DEBSECAN_OUTPUT}" = "" ] && [ ! "${DEBSECAN_SOURCE_URL}" = "" ] && [ ! "${DISTRO_CODENAME}" = "" ]; then
             DEBSECAN_OUTPUT=$(debsecan --suite "${DISTRO_CODENAME}" --format summary 2>/dev/null)
         fi
 
+        if [ "${DEBSECAN_OUTPUT}" = "" ]; then
+            DEBSECAN_OUTPUT=$(debsecan --format summary 2>/dev/null)
+        fi
+
         Report "debsecan_filter=high urgency"
-        DEBSECAN_OUTPUT=$(printf '%s\n' "${DEBSECAN_OUTPUT}" | grep -i "high urgency")
+        DEBSECAN_OUTPUT=$(printf '%s\n' "${DEBSECAN_OUTPUT}" | grep -Ei "high urgency|urgency high")
 
         # Extract CVE identifiers and deduplicate
         CVE_LIST=$(printf '%s\n' "${DEBSECAN_OUTPUT}" | grep -Eo 'CVE-[0-9]{4}-[0-9]+' | sort -u)


### PR DESCRIPTION
## Summary
- use Ubuntu debsecan source `https://trikusec.github.io/ubt2dsa/release/1/`
- prefer suite+source summary mode on Ubuntu, with robust fallbacks
- keep `--format summary` and filter high urgency entries (`high urgency|urgency high`)
- export deduplicated CVE list (`debsecan_cve[]`, `debsecan_cve_list`, `debsecan_cve_count`)

## Validation
- `sh -n trikusec-lynis-plugin/plugin_trikusec_phase1`
