### PR TITLE
feat: customizable optional columns in device list

### DIFF
--- a/src/frontend/static/js/devices.js
+++ b/src/frontend/static/js/devices.js
@@ -88,7 +88,8 @@ const DEVICE_OPTIONAL_COLUMNS = [
 ];
 const DEVICE_COLUMN_PREFS_KEY = 'trikusec.device-list.optional-columns.v1';
 const DEVICE_MAX_TOTAL_COLUMNS = 10;
-const DEVICE_MANDATORY_COLUMNS = 4;
+// Existing non-optional table columns that remain always visible
+const DEVICE_MANDATORY_COLUMNS = 8;
 
 document.addEventListener('DOMContentLoaded', function() {
     const searchContainer = document.getElementById('device-search-container');
@@ -114,15 +115,16 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             const raw = localStorage.getItem(DEVICE_COLUMN_PREFS_KEY);
             if (!raw) {
-                return [...DEVICE_OPTIONAL_COLUMNS];
+                // Keep legacy columns visible by default; optional ones start hidden
+                return [];
             }
             const parsed = JSON.parse(raw);
             if (!Array.isArray(parsed)) {
-                return [...DEVICE_OPTIONAL_COLUMNS];
+                return [];
             }
             return parsed.filter((key) => DEVICE_OPTIONAL_COLUMNS.includes(key));
         } catch (_) {
-            return [...DEVICE_OPTIONAL_COLUMNS];
+            return [];
         }
     }
 

--- a/src/frontend/static/js/devices.js
+++ b/src/frontend/static/js/devices.js
@@ -77,11 +77,28 @@ function deleteDevice(deviceId, hostname) {
     });
 }
 
-// Device search toggle - using event delegation for Firefox compatibility
+// Device search toggle + column customization
+
+const DEVICE_OPTIONAL_COLUMNS = [
+    'uptime',
+    'trikusec_plugin',
+    'antivirus',
+    'vulnerable_packages',
+    'non_compliant_days',
+];
+const DEVICE_COLUMN_PREFS_KEY = 'trikusec.device-list.optional-columns.v1';
+const DEVICE_MAX_TOTAL_COLUMNS = 10;
+const DEVICE_MANDATORY_COLUMNS = 4;
+
 document.addEventListener('DOMContentLoaded', function() {
     const searchContainer = document.getElementById('device-search-container');
     const searchInput = document.getElementById('device-search-input');
     const deviceRows = document.querySelectorAll('tbody tr[data-device-name]');
+
+    const columnsToggleButton = document.getElementById('device-columns-toggle');
+    const columnsPanel = document.getElementById('device-columns-panel');
+    const columnsLimitMsg = document.getElementById('device-columns-limit-msg');
+    const columnCheckboxes = document.querySelectorAll('[data-column-checkbox]');
 
     function filterDevices(term) {
         const normalized = term.trim().toLowerCase();
@@ -93,9 +110,68 @@ document.addEventListener('DOMContentLoaded', function() {
         });
     }
 
+    function loadOptionalColumnsPreference() {
+        try {
+            const raw = localStorage.getItem(DEVICE_COLUMN_PREFS_KEY);
+            if (!raw) {
+                return [...DEVICE_OPTIONAL_COLUMNS];
+            }
+            const parsed = JSON.parse(raw);
+            if (!Array.isArray(parsed)) {
+                return [...DEVICE_OPTIONAL_COLUMNS];
+            }
+            return parsed.filter((key) => DEVICE_OPTIONAL_COLUMNS.includes(key));
+        } catch (_) {
+            return [...DEVICE_OPTIONAL_COLUMNS];
+        }
+    }
+
+    function saveOptionalColumnsPreference(selectedColumns) {
+        try {
+            localStorage.setItem(DEVICE_COLUMN_PREFS_KEY, JSON.stringify(selectedColumns));
+        } catch (_) {
+            // Ignore persistence errors (e.g., private browsing quota restrictions)
+        }
+    }
+
+    function updateColumnSelectionLimits(selectedColumns) {
+        if (!columnCheckboxes.length) {
+            return;
+        }
+
+        const maxOptionalColumns = DEVICE_MAX_TOTAL_COLUMNS - DEVICE_MANDATORY_COLUMNS;
+        const maxReached = selectedColumns.length >= maxOptionalColumns;
+
+        columnCheckboxes.forEach((checkbox) => {
+            if (!checkbox.checked) {
+                checkbox.disabled = maxReached;
+            }
+        });
+
+        if (columnsLimitMsg) {
+            columnsLimitMsg.classList.toggle('hidden', !maxReached);
+        }
+    }
+
+    function applyOptionalColumns(selectedColumns) {
+        DEVICE_OPTIONAL_COLUMNS.forEach((columnKey) => {
+            const shouldShow = selectedColumns.includes(columnKey);
+            const nodes = document.querySelectorAll(`[data-optional-column="${columnKey}"]`);
+            nodes.forEach((node) => node.classList.toggle('hidden', !shouldShow));
+        });
+
+        columnCheckboxes.forEach((checkbox) => {
+            const columnKey = checkbox.getAttribute('data-column-checkbox');
+            checkbox.checked = selectedColumns.includes(columnKey);
+        });
+
+        updateColumnSelectionLimits(selectedColumns);
+    }
+
     // Use event delegation on document to avoid Firefox issues with hidden elements
     document.addEventListener('click', function(e) {
         const searchToggle = e.target.closest('#device-search-toggle');
+        const columnsToggle = e.target.closest('#device-columns-toggle');
 
         if (searchToggle && searchContainer) {
             const wasOpen = searchContainer.classList.contains('max-w-xs');
@@ -104,14 +180,20 @@ document.addEventListener('DOMContentLoaded', function() {
             searchContainer.classList.toggle('opacity-100');
 
             if (!wasOpen && searchInput) {
-                // Wait a bit so the transition starts, then focus
                 setTimeout(() => searchInput.focus(), 150);
             } else if (wasOpen) {
-                // Closing the search panel should clear filters
                 if (searchInput) {
                     searchInput.value = '';
                 }
                 filterDevices('');
+            }
+        }
+
+        if (columnsToggle && columnsPanel) {
+            columnsPanel.classList.toggle('hidden');
+        } else if (columnsPanel && columnsToggleButton && !columnsPanel.classList.contains('hidden')) {
+            if (!columnsPanel.contains(e.target) && !columnsToggleButton.contains(e.target)) {
+                columnsPanel.classList.add('hidden');
             }
         }
     });
@@ -119,6 +201,31 @@ document.addEventListener('DOMContentLoaded', function() {
     if (searchInput) {
         searchInput.addEventListener('input', (event) => {
             filterDevices(event.target.value);
+        });
+    }
+
+    if (columnCheckboxes.length) {
+        let selectedColumns = loadOptionalColumnsPreference();
+        applyOptionalColumns(selectedColumns);
+
+        columnCheckboxes.forEach((checkbox) => {
+            checkbox.addEventListener('change', (event) => {
+                const columnKey = event.target.getAttribute('data-column-checkbox');
+                if (!columnKey) {
+                    return;
+                }
+
+                if (event.target.checked) {
+                    if (!selectedColumns.includes(columnKey)) {
+                        selectedColumns = [...selectedColumns, columnKey];
+                    }
+                } else {
+                    selectedColumns = selectedColumns.filter((key) => key !== columnKey);
+                }
+
+                applyOptionalColumns(selectedColumns);
+                saveOptionalColumnsPreference(selectedColumns);
+            });
         });
     }
 });

--- a/src/frontend/static/js/devices.js
+++ b/src/frontend/static/js/devices.js
@@ -97,7 +97,7 @@ const DEVICE_DEFAULT_VISIBLE_OPTIONAL_COLUMNS = [
     'lynis_version',
     'warnings',
 ];
-const DEVICE_COLUMN_PREFS_KEY = 'trikusec.device-list.optional-columns.v1';
+const DEVICE_COLUMN_PREFS_KEY = 'trikusec.device-list.optional-columns.v2';
 const DEVICE_MAX_TOTAL_COLUMNS = 10;
 const DEVICE_MANDATORY_COLUMNS = 4;
 

--- a/src/frontend/static/js/devices.js
+++ b/src/frontend/static/js/devices.js
@@ -80,16 +80,26 @@ function deleteDevice(deviceId, hostname) {
 // Device search toggle + column customization
 
 const DEVICE_OPTIONAL_COLUMNS = [
+    'os_version',
+    'hardening_index',
+    'lynis_version',
+    'warnings',
     'uptime',
     'trikusec_plugin',
     'antivirus',
     'vulnerable_packages',
     'non_compliant_days',
 ];
+
+const DEVICE_DEFAULT_VISIBLE_OPTIONAL_COLUMNS = [
+    'os_version',
+    'hardening_index',
+    'lynis_version',
+    'warnings',
+];
 const DEVICE_COLUMN_PREFS_KEY = 'trikusec.device-list.optional-columns.v1';
 const DEVICE_MAX_TOTAL_COLUMNS = 10;
-// Existing non-optional table columns that remain always visible
-const DEVICE_MANDATORY_COLUMNS = 8;
+const DEVICE_MANDATORY_COLUMNS = 4;
 
 document.addEventListener('DOMContentLoaded', function() {
     const searchContainer = document.getElementById('device-search-container');
@@ -115,16 +125,15 @@ document.addEventListener('DOMContentLoaded', function() {
         try {
             const raw = localStorage.getItem(DEVICE_COLUMN_PREFS_KEY);
             if (!raw) {
-                // Keep legacy columns visible by default; optional ones start hidden
-                return [];
+                return [...DEVICE_DEFAULT_VISIBLE_OPTIONAL_COLUMNS];
             }
             const parsed = JSON.parse(raw);
             if (!Array.isArray(parsed)) {
-                return [];
+                return [...DEVICE_DEFAULT_VISIBLE_OPTIONAL_COLUMNS];
             }
             return parsed.filter((key) => DEVICE_OPTIONAL_COLUMNS.includes(key));
         } catch (_) {
-            return [];
+            return [...DEVICE_DEFAULT_VISIBLE_OPTIONAL_COLUMNS];
         }
     }
 

--- a/src/frontend/templates/device_list.html
+++ b/src/frontend/templates/device_list.html
@@ -53,28 +53,117 @@
                 <thead>
                     <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
                         <th class="py-3 px-6 text-left">
-                            <a href="?sort=hostname&order={% if current_sort == 'hostname' and current_order == 'asc' %}desc{% else %}asc{% endif %}"
+                            <a href="?sort=hostname&order={% if current_sort == 'hostname' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
                                class="flex items-center space-x-1 hover:text-gray-900 transition-colors">
                                 <span>Name</span>
+                                {% if current_sort == 'hostname' %}
+                                    {% if current_order == 'asc' %}
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
+                                        </svg>
+                                    {% else %}
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                        </svg>
+                                    {% endif %}
+                                {% else %}
+                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
+                                    </svg>
+                                {% endif %}
                             </a>
                         </th>
-                        <th class="py-3 px-6 text-left">OS</th>
+                        <th class="py-3 px-6 text-left w-4">OS</th>
+                        <th class="py-3 px-6 text-left">OS Version</th>
+                        <th class="py-3 px-6 text-center">
+                            <a href="?sort=hardening_index&order={% if current_sort == 'hardening_index' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
+                               class="flex items-center justify-center space-x-1 hover:text-gray-900 transition-colors">
+                                <span>HARD INDEX</span>
+                                {% if current_sort == 'hardening_index' %}
+                                    {% if current_order == 'asc' %}
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
+                                        </svg>
+                                    {% else %}
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                        </svg>
+                                    {% endif %}
+                                {% else %}
+                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
+                                    </svg>
+                                {% endif %}
+                            </a>
+                        </th>
+                        <th class="py-3 px-6 text-left">LYNIS</th>
                         <th class="py-3 px-6 text-left" data-optional-column="uptime">Uptime</th>
                         <th class="py-3 px-6 text-left" data-optional-column="trikusec_plugin">TrikuSec Lynis Plugin</th>
                         <th class="py-3 px-6 text-left" data-optional-column="antivirus">Antivirus</th>
                         <th class="py-3 px-6 text-center" data-optional-column="vulnerable_packages">Vulnerable Packages</th>
                         <th class="py-3 px-6 text-center" data-optional-column="non_compliant_days">Total Days Non-Compliant</th>
                         <th class="py-3 px-6 text-left">
-                            <a href="?sort=compliant&order={% if current_sort == 'compliant' and current_order == 'asc' %}desc{% else %}asc{% endif %}"
+                            <a href="?sort=compliant&order={% if current_sort == 'compliant' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
                                class="flex items-center space-x-1 hover:text-gray-900 transition-colors">
                                 <span>Compliant</span>
+                                {% if current_sort == 'compliant' %}
+                                    {% if current_order == 'asc' %}
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
+                                        </svg>
+                                    {% else %}
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                        </svg>
+                                    {% endif %}
+                                {% else %}
+                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
+                                    </svg>
+                                {% endif %}
+                            </a>
+                        </th>
+                        <th class="py-3 px-6 text-center">
+                            <a href="?sort=warnings&order={% if current_sort == 'warnings' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
+                               class="flex items-center justify-center space-x-1 hover:text-gray-900 transition-colors">
+                                <span>Warnings</span>
+                                {% if current_sort == 'warnings' %}
+                                    {% if current_order == 'asc' %}
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
+                                        </svg>
+                                    {% else %}
+                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                        </svg>
+                                    {% endif %}
+                                {% else %}
+                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
+                                    </svg>
+                                {% endif %}
                             </a>
                         </th>
                         <th class="py-3 px-6 text-left relative">
                             <div class="flex items-center justify-between gap-2">
-                                <a href="?sort=last_update&order={% if current_sort == 'last_update' and current_order == 'asc' %}desc{% else %}asc{% endif %}"
+                                <a href="?sort=last_update&order={% if current_sort == 'last_update' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
                                    class="flex items-center space-x-1 hover:text-gray-900 transition-colors">
                                     <span>Last Updated</span>
+                                    {% if current_sort == 'last_update' %}
+                                        {% if current_order == 'asc' %}
+                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
+                                            </svg>
+                                        {% else %}
+                                            <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                                <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
+                                            </svg>
+                                        {% endif %}
+                                    {% else %}
+                                        <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
+                                        </svg>
+                                    {% endif %}
                                 </a>
                                 <button id="device-columns-toggle" type="button" class="inline-flex items-center justify-center w-7 h-7 rounded-md border border-gray-300 bg-white text-gray-600 hover:bg-gray-100" title="Customize columns" aria-label="Customize columns">
                                     <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
@@ -119,10 +208,24 @@
                                 <span class="font-medium"><a href="{% url 'device_detail' device_id=device.id %}">{{ device.hostname|default:device.hostid }}</a></span>
                             </div>
                         </td>
-                        <td class="py-3 px-6 text-left">
-                            <div class="flex items-center gap-2">
+                        <td class="py-3 px-4 text-center w-4">
+                            <span>
                                 {{ device.distro|distro_icon }}
+                            </span>
+                        </td>
+                        <td class="py-3 px-6 text-left">
+                            <div class="flex items-center">
                                 <span>{{ device.distro|default:device.os|default:"-" }}</span>
+                            </div>
+                        </td>
+                        <td class="py-3 px-6 text-center">
+                            <div class="flex items-center justify-center">
+                                <span>{% if device.hardening_index %}{{ device.hardening_index }}{% else %}-{% endif %}</span>
+                            </div>
+                        </td>
+                        <td class="py-3 px-6 text-left">
+                            <div class="flex items-center">
+                                <span>{{ device.lynis_version|default:"-" }}</span>
                             </div>
                         </td>
                         <td class="py-3 px-6 text-left" data-optional-column="uptime">
@@ -153,13 +256,16 @@
                             <span class="bg-red-200 text-red-600 py-1 px-3 rounded-full text-xs">Not Compliant</span>
                             {% endif %}
                         </td>
+                        <td class="py-3 px-6 text-center">
+                            <span class="bg-yellow-200 text-yellow-600 py-1 px-3 rounded-full text-xs">{{ device.warnings }}</span>
+                        </td>
                         <td class="py-3 px-6 text-left">
                             <span>{{ device.last_update|timesince }}</span>
                         </td>
                     </tr>
                     {% empty %}
                     <tr>
-                        <td colspan="9" class="py-6 px-6 text-center text-gray-500">
+                        <td colspan="13" class="py-6 px-6 text-center text-gray-500">
                             No devices found.
                         </td>
                     </tr>

--- a/src/frontend/templates/device_list.html
+++ b/src/frontend/templates/device_list.html
@@ -74,8 +74,8 @@
                             </a>
                         </th>
                         <th class="py-3 px-6 text-left w-4">OS</th>
-                        <th class="py-3 px-6 text-left">OS Version</th>
-                        <th class="py-3 px-6 text-center">
+                        <th class="py-3 px-6 text-left" data-optional-column="os_version">OS Version</th>
+                        <th class="py-3 px-6 text-center" data-optional-column="hardening_index">
                             <a href="?sort=hardening_index&order={% if current_sort == 'hardening_index' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
                                class="flex items-center justify-center space-x-1 hover:text-gray-900 transition-colors">
                                 <span>HARD INDEX</span>
@@ -96,7 +96,7 @@
                                 {% endif %}
                             </a>
                         </th>
-                        <th class="py-3 px-6 text-left">LYNIS</th>
+                        <th class="py-3 px-6 text-left" data-optional-column="lynis_version">LYNIS</th>
                         <th class="py-3 px-6 text-left" data-optional-column="uptime">Uptime</th>
                         <th class="py-3 px-6 text-left" data-optional-column="trikusec_plugin">TrikuSec Lynis Plugin</th>
                         <th class="py-3 px-6 text-left" data-optional-column="antivirus">Antivirus</th>
@@ -123,7 +123,7 @@
                                 {% endif %}
                             </a>
                         </th>
-                        <th class="py-3 px-6 text-center">
+                        <th class="py-3 px-6 text-center" data-optional-column="warnings">
                             <a href="?sort=warnings&order={% if current_sort == 'warnings' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
                                class="flex items-center justify-center space-x-1 hover:text-gray-900 transition-colors">
                                 <span>Warnings</span>
@@ -175,6 +175,22 @@
                                 <p class="text-xs text-gray-500 mb-2">AVAILABLE COLUMNS:</p>
                                 <div class="space-y-2 text-xs text-gray-700">
                                     <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="os_version" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>OS Version</span>
+                                    </label>
+                                    <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="hardening_index" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>Hard Index</span>
+                                    </label>
+                                    <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="lynis_version" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>Lynis Version</span>
+                                    </label>
+                                    <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="warnings" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>Warnings</span>
+                                    </label>
+                                    <label class="flex items-center gap-2">
                                         <input type="checkbox" data-column-checkbox="uptime" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
                                         <span>Uptime</span>
                                     </label>
@@ -213,17 +229,17 @@
                                 {{ device.distro|distro_icon }}
                             </span>
                         </td>
-                        <td class="py-3 px-6 text-left">
+                        <td class="py-3 px-6 text-left" data-optional-column="os_version">
                             <div class="flex items-center">
                                 <span>{{ device.distro|default:device.os|default:"-" }}</span>
                             </div>
                         </td>
-                        <td class="py-3 px-6 text-center">
+                        <td class="py-3 px-6 text-center" data-optional-column="hardening_index">
                             <div class="flex items-center justify-center">
                                 <span>{% if device.hardening_index %}{{ device.hardening_index }}{% else %}-{% endif %}</span>
                             </div>
                         </td>
-                        <td class="py-3 px-6 text-left">
+                        <td class="py-3 px-6 text-left" data-optional-column="lynis_version">
                             <div class="flex items-center">
                                 <span>{{ device.lynis_version|default:"-" }}</span>
                             </div>
@@ -256,7 +272,7 @@
                             <span class="bg-red-200 text-red-600 py-1 px-3 rounded-full text-xs">Not Compliant</span>
                             {% endif %}
                         </td>
-                        <td class="py-3 px-6 text-center">
+                        <td class="py-3 px-6 text-center" data-optional-column="warnings">
                             <span class="bg-yellow-200 text-yellow-600 py-1 px-3 rounded-full text-xs">{{ device.warnings }}</span>
                         </td>
                         <td class="py-3 px-6 text-left">

--- a/src/frontend/templates/device_list.html
+++ b/src/frontend/templates/device_list.html
@@ -172,7 +172,7 @@
                                 </button>
                             </div>
                             <div id="device-columns-panel" class="hidden absolute right-2 top-12 z-20 w-72 rounded-md border border-gray-200 bg-white shadow-lg p-3 normal-case">
-                                <p class="text-xs text-gray-500 mb-2">Select optional columns (max 10 total columns).</p>
+                                <p class="text-xs text-gray-500 mb-2">AVAILABLE COLUMNS:</p>
                                 <div class="space-y-2 text-xs text-gray-700">
                                     <label class="flex items-center gap-2">
                                         <input type="checkbox" data-column-checkbox="uptime" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">

--- a/src/frontend/templates/device_list.html
+++ b/src/frontend/templates/device_list.html
@@ -171,7 +171,7 @@
                                     </svg>
                                 </button>
                             </div>
-                            <div id="device-columns-panel" class="hidden absolute right-2 top-12 z-20 w-72 rounded-md border border-gray-200 bg-white shadow-lg p-3 normal-case">
+                            <div id="device-columns-panel" class="hidden absolute right-0 top-full mt-2 z-20 w-72 rounded-md border border-gray-200 bg-white shadow-lg p-3 normal-case">
                                 <p class="text-xs text-gray-500 mb-2">AVAILABLE COLUMNS:</p>
                                 <div class="space-y-2 text-xs text-gray-700">
                                     <label class="flex items-center gap-2">

--- a/src/frontend/templates/device_list.html
+++ b/src/frontend/templates/device_list.html
@@ -53,143 +53,97 @@
                 <thead>
                     <tr class="bg-gray-200 text-gray-600 uppercase text-sm leading-normal">
                         <th class="py-3 px-6 text-left">
-                            <a href="?sort=hostname&order={% if current_sort == 'hostname' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
+                            <a href="?sort=hostname&order={% if current_sort == 'hostname' and current_order == 'asc' %}desc{% else %}asc{% endif %}"
                                class="flex items-center space-x-1 hover:text-gray-900 transition-colors">
                                 <span>Name</span>
-                                {% if current_sort == 'hostname' %}
-                                    {% if current_order == 'asc' %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
-                                        </svg>
-                                    {% else %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-                                        </svg>
-                                    {% endif %}
-                                {% else %}
-                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
-                                    </svg>
-                                {% endif %}
                             </a>
                         </th>
-                        <th class="py-3 px-6 text-left w-4">OS</th>
-                        <th class="py-3 px-6 text-left">OS Version</th>
-                        <th class="py-3 px-6 text-center">
-                            <a href="?sort=hardening_index&order={% if current_sort == 'hardening_index' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
-                               class="flex items-center justify-center space-x-1 hover:text-gray-900 transition-colors">
-                                <span>HARD INDEX</span>
-                                {% if current_sort == 'hardening_index' %}
-                                    {% if current_order == 'asc' %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
-                                        </svg>
-                                    {% else %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-                                        </svg>
-                                    {% endif %}
-                                {% else %}
-                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
-                                    </svg>
-                                {% endif %}
-                            </a>
-                        </th>
-                        <th class="py-3 px-6 text-left">LYNIS</th>
+                        <th class="py-3 px-6 text-left">OS</th>
+                        <th class="py-3 px-6 text-left" data-optional-column="uptime">Uptime</th>
+                        <th class="py-3 px-6 text-left" data-optional-column="trikusec_plugin">TrikuSec Lynis Plugin</th>
+                        <th class="py-3 px-6 text-left" data-optional-column="antivirus">Antivirus</th>
+                        <th class="py-3 px-6 text-center" data-optional-column="vulnerable_packages">Vulnerable Packages</th>
+                        <th class="py-3 px-6 text-center" data-optional-column="non_compliant_days">Total Days Non-Compliant</th>
                         <th class="py-3 px-6 text-left">
-                            <a href="?sort=compliant&order={% if current_sort == 'compliant' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
+                            <a href="?sort=compliant&order={% if current_sort == 'compliant' and current_order == 'asc' %}desc{% else %}asc{% endif %}"
                                class="flex items-center space-x-1 hover:text-gray-900 transition-colors">
                                 <span>Compliant</span>
-                                {% if current_sort == 'compliant' %}
-                                    {% if current_order == 'asc' %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
-                                        </svg>
-                                    {% else %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-                                        </svg>
-                                    {% endif %}
-                                {% else %}
-                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
-                                    </svg>
-                                {% endif %}
                             </a>
                         </th>
-                        <th class="py-3 px-6 text-center">
-                            <a href="?sort=warnings&order={% if current_sort == 'warnings' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
-                               class="flex items-center justify-center space-x-1 hover:text-gray-900 transition-colors">
-                                <span>Warnings</span>
-                                {% if current_sort == 'warnings' %}
-                                    {% if current_order == 'asc' %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
-                                        </svg>
-                                    {% else %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-                                        </svg>
-                                    {% endif %}
-                                {% else %}
-                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
+                        <th class="py-3 px-6 text-left relative">
+                            <div class="flex items-center justify-between gap-2">
+                                <a href="?sort=last_update&order={% if current_sort == 'last_update' and current_order == 'asc' %}desc{% else %}asc{% endif %}"
+                                   class="flex items-center space-x-1 hover:text-gray-900 transition-colors">
+                                    <span>Last Updated</span>
+                                </a>
+                                <button id="device-columns-toggle" type="button" class="inline-flex items-center justify-center w-7 h-7 rounded-md border border-gray-300 bg-white text-gray-600 hover:bg-gray-100" title="Customize columns" aria-label="Customize columns">
+                                    <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor" class="w-4 h-4">
+                                        <path stroke-linecap="round" stroke-linejoin="round" d="M4.5 12a7.5 7.5 0 0 0 15 0 7.5 7.5 0 0 0-15 0Zm7.5 3a3 3 0 1 0 0-6 3 3 0 0 0 0 6Z" />
                                     </svg>
-                                {% endif %}
-                            </a>
-                        </th>
-                        <th class="py-3 px-6 text-left">
-                            <a href="?sort=last_update&order={% if current_sort == 'last_update' and current_order == 'asc' %}desc{% else %}asc{% endif %}" 
-                               class="flex items-center space-x-1 hover:text-gray-900 transition-colors">
-                                <span>Last Updated</span>
-                                {% if current_sort == 'last_update' %}
-                                    {% if current_order == 'asc' %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M5 15l7-7 7 7"></path>
-                                        </svg>
-                                    {% else %}
-                                        <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7"></path>
-                                        </svg>
-                                    {% endif %}
-                                {% else %}
-                                    <svg class="w-4 h-4 opacity-30" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                                        <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 16V4m0 0L3 8m4-4l4 4m6 0v12m0 0l4-4m-4 4l-4-4"></path>
-                                    </svg>
-                                {% endif %}
-                            </a>
+                                </button>
+                            </div>
+                            <div id="device-columns-panel" class="hidden absolute right-2 top-12 z-20 w-72 rounded-md border border-gray-200 bg-white shadow-lg p-3 normal-case">
+                                <p class="text-xs text-gray-500 mb-2">Select optional columns (max 10 total columns).</p>
+                                <div class="space-y-2 text-xs text-gray-700">
+                                    <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="uptime" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>Uptime</span>
+                                    </label>
+                                    <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="trikusec_plugin" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>TrikuSec Lynis Plugin</span>
+                                    </label>
+                                    <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="antivirus" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>Antivirus</span>
+                                    </label>
+                                    <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="vulnerable_packages" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>Vulnerable Packages (count)</span>
+                                    </label>
+                                    <label class="flex items-center gap-2">
+                                        <input type="checkbox" data-column-checkbox="non_compliant_days" class="rounded border-gray-300 text-blue-600 focus:ring-blue-500">
+                                        <span>Total Days Non-Compliant</span>
+                                    </label>
+                                </div>
+                                <p id="device-columns-limit-msg" class="mt-2 text-xs text-amber-600 hidden">Maximum number of columns reached.</p>
+                            </div>
                         </th>
                     </tr>
                 </thead>
                 <tbody class="text-gray-600 text-sm font-light">
                     {% for device in devices %}
-                    <tr class="border-b border-gray-200 hover:bg-gray-100" data-device-name="{{ device.hostname|lower }}">
+                    <tr class="border-b border-gray-200 hover:bg-gray-100" data-device-name="{{ device.hostname|default:device.hostid|lower }}">
                         <td class="py-3 px-6 text-left whitespace-nowrap">
                             <div class="flex items-center">
-                                <span class="font-medium"><a href="{% url 'device_detail' device_id=device.id %}">{{ device.hostname }}</a></span>
+                                <span class="font-medium"><a href="{% url 'device_detail' device_id=device.id %}">{{ device.hostname|default:device.hostid }}</a></span>
                             </div>
                         </td>
-                        <td class="py-3 px-4 text-center w-4">
-                            <span>
+                        <td class="py-3 px-6 text-left">
+                            <div class="flex items-center gap-2">
                                 {{ device.distro|distro_icon }}
-                            </span>
-                        </td>
-                        <td class="py-3 px-6 text-left">
-                            <div class="flex items-center">
-                                <span>{{ device.distro }}</span>
+                                <span>{{ device.distro|default:device.os|default:"-" }}</span>
                             </div>
                         </td>
-                        <td class="py-3 px-6 text-center">
-                            <div class="flex items-center justify-center">
-                                <span>{% if device.hardening_index %}{{ device.hardening_index }}{% else %}-{% endif %}</span>
-                            </div>
+                        <td class="py-3 px-6 text-left" data-optional-column="uptime">
+                            {% if device.uptime_in_days is not None %}{{ device.uptime_in_days }} d{% else %}-{% endif %}
                         </td>
-                        <td class="py-3 px-6 text-left">
-                            <div class="flex items-center">
-                                <span>{{ device.lynis_version|default:"-" }}</span>
-                            </div>
+                        <td class="py-3 px-6 text-left" data-optional-column="trikusec_plugin">
+                            {% if device.trikusec_plugin_installed %}
+                                <span class="bg-green-100 text-green-700 py-1 px-2 rounded-full text-xs">Installed</span>
+                            {% else %}
+                                <span class="bg-gray-200 text-gray-700 py-1 px-2 rounded-full text-xs">Not installed</span>
+                            {% endif %}
                         </td>
+                        <td class="py-3 px-6 text-left" data-optional-column="antivirus">
+                            {% if device.antivirus_installed %}
+                                <span class="bg-green-100 text-green-700 py-1 px-2 rounded-full text-xs">Installed</span>
+                            {% else %}
+                                <span class="bg-gray-200 text-gray-700 py-1 px-2 rounded-full text-xs">Not installed</span>
+                            {% endif %}
+                        </td>
+                        <td class="py-3 px-6 text-center" data-optional-column="vulnerable_packages">{{ device.vulnerable_packages_count }}</td>
+                        <td class="py-3 px-6 text-center" data-optional-column="non_compliant_days">{{ device.total_days_non_compliant }}</td>
                         <td class="py-3 px-6 text-left">
                             {% if device.ruleset_count == 0 %}
                             <span class="bg-gray-200 text-gray-700 py-1 px-3 rounded-full text-xs">Unknown</span>
@@ -199,21 +153,17 @@
                             <span class="bg-red-200 text-red-600 py-1 px-3 rounded-full text-xs">Not Compliant</span>
                             {% endif %}
                         </td>
-                        <td class="py-3 px-6 text-center">
-                            <span class="bg-yellow-200 text-yellow-600 py-1 px-3 rounded-full text-xs">{{ device.warnings }}</span>
-                        </td>
                         <td class="py-3 px-6 text-left">
                             <span>{{ device.last_update|timesince }}</span>
                         </td>
                     </tr>
                     {% empty %}
                     <tr>
-                        <td colspan="8" class="py-6 px-6 text-center text-gray-500">
+                        <td colspan="9" class="py-6 px-6 text-center text-gray-500">
                             No devices found.
                         </td>
                     </tr>
                     {% endfor %}
-
                 </tbody>
             </table>
         </div>

--- a/src/frontend/tests.py
+++ b/src/frontend/tests.py
@@ -5,7 +5,7 @@ from django.urls import reverse
 from django.contrib.auth.models import User
 from django.utils import timezone
 from datetime import timedelta
-from api.models import Device, FullReport, DiffReport, DeviceEvent, EnrollmentSettings, EnrollmentPlugin, EnrollmentPackage, EnrollmentSkipTest
+from api.models import Device, FullReport, DiffReport, DeviceEvent, EnrollmentSettings, EnrollmentPlugin, EnrollmentPackage, EnrollmentSkipTest, PolicyRuleset
 from frontend.templatetags import custom_filters
 from frontend.views import DEVICE_LIST_PAGE_SIZE
 from frontend.forms import (
@@ -327,6 +327,76 @@ class TestDeviceComplianceUnknownStatus:
 
         assert response.status_code == 200
         assert b'Unknown' in response.content
+
+
+@pytest.mark.django_db
+class TestDeviceListCustomizableColumns:
+    """Tests for device list optional/customizable columns."""
+
+    def test_device_list_shows_optional_column_controls(self, test_user, test_device, sample_lynis_report):
+        client = Client()
+        client.force_login(test_user)
+
+        FullReport.objects.create(device=test_device, full_report=sample_lynis_report)
+
+        response = client.get(reverse('device_list'))
+
+        assert response.status_code == 200
+        body = response.content.decode()
+        assert 'Uptime' in body
+        assert 'TrikuSec Lynis Plugin' in body
+        assert 'Antivirus' in body
+        assert 'Vulnerable Packages (count)' in body
+        assert 'Total Days Non-Compliant' in body
+
+    def test_device_list_enriches_optional_column_values(self, test_user, test_license_key):
+        client = Client()
+        client.force_login(test_user)
+
+        device = Device.objects.create(
+            licensekey=test_license_key,
+            hostid='feature-host-1',
+            hostid2='feature-host-2',
+            hostname='feature-device',
+            os='Linux',
+            distro='Ubuntu',
+            compliant=False,
+            warnings=2,
+            last_update=timezone.now() - timedelta(days=4),
+        )
+
+        ruleset = PolicyRuleset.objects.create(name='Test ruleset', description='Ruleset for testing')
+        device.rulesets.add(ruleset)
+
+        DeviceEvent.objects.create(
+            device=device,
+            event_type='compliance_changed',
+            metadata={'old_status': 'Compliant', 'new_status': 'Non-Compliant'},
+        )
+        event = DeviceEvent.objects.filter(device=device, event_type='compliance_changed').first()
+        event.created_at = timezone.now() - timedelta(days=3)
+        event.save(update_fields=['created_at'])
+
+        report = """# Lynis Report
+hostname=feature-device
+os=Linux
+uptime_in_days=12
+trikusec_custom_tests=1
+clamav_version=ClamAV 1.2.3
+vulnerable_packages_found=7
+report_datetime_end=2024-01-01 10:05:00
+"""
+        FullReport.objects.create(device=device, full_report=report)
+
+        response = client.get(reverse('device_list'))
+
+        assert response.status_code == 200
+        listed_device = next(d for d in response.context['devices'].object_list if d.id == device.id)
+        assert listed_device.uptime_in_days == 12
+        assert listed_device.trikusec_plugin_installed is True
+        assert listed_device.antivirus_installed is True
+        assert listed_device.vulnerable_packages_count == 7
+        assert listed_device.total_days_non_compliant == 3
 
 
 @pytest.mark.django_db

--- a/src/frontend/views.py
+++ b/src/frontend/views.py
@@ -392,32 +392,91 @@ def onboarding(request):
 
 @login_required
 def device_list(request):
-    """Device list view: show all devices"""
+    """Device list view: show all devices."""
+    from django.utils import timezone as tz
+
+    now = tz.now()
+
+    def enrich_device_for_list(device, parsed_report):
+        """Attach computed fields used by the device list optional columns."""
+        device.hardening_index = None
+        device.uptime_in_days = None
+        device.trikusec_plugin_installed = False
+        device.antivirus_installed = False
+        device.vulnerable_packages_count = 0
+        device.total_days_non_compliant = 0
+
+        if isinstance(parsed_report, dict):
+            device.hardening_index = parsed_report.get('hardening_index', None)
+
+            uptime_days = parsed_report.get('uptime_in_days')
+            try:
+                device.uptime_in_days = int(uptime_days) if uptime_days is not None else None
+            except (TypeError, ValueError):
+                device.uptime_in_days = None
+
+            installed_package_names = parsed_report.get('installed_package_names') or []
+            if not isinstance(installed_package_names, list):
+                installed_package_names = []
+
+            device.trikusec_plugin_installed = parsed_report.get('trikusec_custom_tests') in (1, '1', True)
+            if not device.trikusec_plugin_installed:
+                device.trikusec_plugin_installed = any(
+                    'trikusec' in pkg.lower() and 'plugin' in pkg.lower()
+                    for pkg in installed_package_names
+                    if isinstance(pkg, str)
+                )
+
+            malware_scanner_installed = parsed_report.get('malware_scanner_installed')
+            clamav_version = parsed_report.get('clamav_version')
+            known_antivirus_packages = {'clamav', 'rkhunter', 'chkrootkit'}
+            package_antivirus_installed = any(
+                any(av_pkg in pkg.lower() for av_pkg in known_antivirus_packages)
+                for pkg in installed_package_names
+                if isinstance(pkg, str)
+            )
+            device.antivirus_installed = (
+                malware_scanner_installed in (1, '1', True)
+                or bool(clamav_version)
+                or package_antivirus_installed
+            )
+
+            vulnerable_packages_found = parsed_report.get('vulnerable_packages_found')
+            if vulnerable_packages_found is None:
+                vulnerable_packages = parsed_report.get('vulnerable_package')
+                if isinstance(vulnerable_packages, list):
+                    device.vulnerable_packages_count = len(vulnerable_packages)
+                else:
+                    device.vulnerable_packages_count = 0
+            else:
+                try:
+                    device.vulnerable_packages_count = int(vulnerable_packages_found)
+                except (TypeError, ValueError):
+                    device.vulnerable_packages_count = 0
+
+        if device.ruleset_count > 0 and not device.compliant:
+            compliance_event = (
+                DeviceEvent.objects
+                .filter(device=device, event_type='compliance_changed')
+                .order_by('-created_at')
+                .first()
+            )
+
+            if compliance_event and compliance_event.metadata.get('new_status') == 'Non-Compliant':
+                non_compliant_since = compliance_event.created_at
+            else:
+                non_compliant_since = device.last_update or device.created_at
+
+            elapsed_days = (now - non_compliant_since).days if non_compliant_since else 0
+            device.total_days_non_compliant = max(0, elapsed_days)
+
     devices_qs = Device.objects.annotate(ruleset_count=Count('rulesets', distinct=True))
     has_devices = devices_qs.exists()
-    
-    # Only process compliance if devices exist
-    if has_devices:
-        for device in devices_qs:
-            logging.debug('Checking compliance for device %s', device)
-            
-            # Get the latest report for the device
-            report = FullReport.objects.filter(device=device).order_by('-created_at').first()
-            if not report:
-                logging.error('No report found for device %s', device)
-                # Don't update compliance here - it should be set on upload
-                continue
-            
-            report = LynisReport(report.full_report)
-            
-            # Only check compliance for display purposes, don't update device or create events
-            # Compliance updates and events should only happen on report upload
-            compliant, _ = check_device_compliance(device, report.get_parsed_report())
-    
+
     # Handle sorting
     sort_field = request.GET.get('sort', 'last_update')
     sort_order = request.GET.get('order', 'desc')
-    
+
     # Validate sort field to prevent SQL injection
     valid_sort_fields = {
         'hostname': 'hostname',
@@ -426,30 +485,27 @@ def device_list(request):
         'last_update': 'last_update',
         'hardening_index': 'hardening_index',
     }
-    
+
     # Default to last_update if invalid sort field
     sort_field = valid_sort_fields.get(sort_field, 'last_update')
-    
+
     # If no devices, return empty list
     if not has_devices:
         devices = []
     # If sorting by hardening_index, we need to extract it first and sort in Python
     elif sort_field == 'hardening_index':
-        # Get all devices first
         devices = list(Device.objects.annotate(ruleset_count=Count('rulesets', distinct=True)))
-        
-        # Extract hardening_index from latest report for each device
+
         for device in devices:
+            parsed_report = None
             latest_report = FullReport.objects.filter(device=device).order_by('-created_at').first()
             if latest_report:
                 try:
                     parsed_report = LynisReport(latest_report.full_report).get_parsed_report()
-                    device.hardening_index = parsed_report.get('hardening_index', None)
                 except Exception:
-                    device.hardening_index = None
-            else:
-                device.hardening_index = None
-        
+                    parsed_report = None
+            enrich_device_for_list(device, parsed_report)
+
         # Sort by hardening_index (treat None as -1 for sorting purposes)
         reverse_order = sort_order == 'desc'
         devices.sort(key=lambda d: d.hardening_index if d.hardening_index is not None else -1, reverse=reverse_order)
@@ -459,23 +515,19 @@ def device_list(request):
             order_by = sort_field
         else:  # default to desc
             order_by = f'-{sort_field}'
-        
+
         # Order devices by selected field
-        devices = Device.objects.annotate(ruleset_count=Count('rulesets', distinct=True)).order_by(order_by)
-        
-        # Extract hardening_index from latest report for each device (for display)
-        devices_list = list(devices)
-        for device in devices_list:
+        devices = list(Device.objects.annotate(ruleset_count=Count('rulesets', distinct=True)).order_by(order_by))
+
+        for device in devices:
+            parsed_report = None
             latest_report = FullReport.objects.filter(device=device).order_by('-created_at').first()
             if latest_report:
                 try:
                     parsed_report = LynisReport(latest_report.full_report).get_parsed_report()
-                    device.hardening_index = parsed_report.get('hardening_index', None)
                 except Exception:
-                    device.hardening_index = None
-            else:
-                device.hardening_index = None
-        devices = devices_list
+                    parsed_report = None
+            enrich_device_for_list(device, parsed_report)
 
     paginator = Paginator(devices, DEVICE_LIST_PAGE_SIZE)
     page_number = request.GET.get('page')


### PR DESCRIPTION
## Summary
- add customizable optional columns in the Devices list view
- keep mandatory columns always visible: Name, OS, Compliant, Last Updated
- add optional columns: Uptime, TrikuSec Lynis Plugin, Antivirus, Vulnerable Packages (count), Total Days Non-Compliant
- add header settings toggle and column selection panel
- persist selected optional columns in localStorage
- enforce maximum visible columns (10 total, including mandatory)
- enrich backend device-list context with computed optional column values
- add frontend tests for column controls and enriched values

## Validation
- docker compose -f docker-compose.dev.yml --profile test run --rm test pytest frontend/tests.py::TestDeviceListPagination frontend/tests.py::TestDeviceComplianceUnknownStatus frontend/tests.py::TestDeviceListCustomizableColumns -v

Closes #133