### PR TITLE
fix: replace wget with curl for nginx healthcheck to avoid IPv6 localhost issues

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       # Domain-based configuration (automatically configures NGINX_CERT_CN)
       - TRIKUSEC_DOMAIN=${TRIKUSEC_DOMAIN}
     healthcheck:
-      test: ["CMD", "wget", "--quiet", "--tries=1", "--spider", "https://localhost:8000/health/", "--no-check-certificate"]
+      test: ["CMD", "curl", "-skf", "https://localhost:8000/health/"]
       interval: 30s
       timeout: 10s
       retries: 3


### PR DESCRIPTION
Replace BusyBox wget with curl in the nginx container healthcheck. BusyBox wget resolves localhost to ::1 on systems with IPv6-enabled Docker (Ubuntu 22/24), but nginx only listens on 127.0.0.1, causing health checks to fail. curl is already available and handles this correctly.

Fixes #139